### PR TITLE
add stride_x_ and stride_y_ for more flexible configuration 

### DIFF
--- a/mshadow/extension/pack_col2patch.h
+++ b/mshadow/extension/pack_col2patch.h
@@ -29,14 +29,16 @@ struct PackColToPatchXExp:
   /*! \brief patch height */
   index_t psize_x_;
   /*! \brief patch stride */
-  index_t pstride_;
+  index_t pstride_y_;
+  index_t pstride_x_;
   /*! \brief constructor */
   PackColToPatchXExp(const SrcExp &src, Shape<dstdim> imshape,
-                     index_t psize_y, index_t psize_x, index_t pstride)
-      :src_(src), psize_y_(psize_y), psize_x_(psize_x), pstride_(pstride){
+                     index_t psize_y, index_t psize_x, index_t pstride_y, index_t pstride_x)
+      :src_(src), psize_y_(psize_y), psize_x_(psize_x),
+       pstride_y_(pstride_y), pstride_x_(pstride_x){
     this->shape_ = imshape;
-    const index_t o_height = (imshape[dstdim - 2] - psize_y) / pstride + 1;
-    const index_t o_width  = (imshape[dstdim - 1] - psize_x) / pstride + 1;
+    const index_t o_height = (imshape[dstdim - 2] - psize_y) / pstride_y + 1;
+    const index_t o_width  = (imshape[dstdim - 1] - psize_x) / pstride_x + 1;
     Shape<2> sshape = ShapeCheck<2, SrcExp>::Check(src_);
     CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
       << "PackColToPatchExp: src.size(1) mismatch";
@@ -67,8 +69,24 @@ pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
   CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
     << "PackColToPatch:image shape smaller than patch size";
   return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
-                                                   psize_y, psize_x, pstride);
+                                                   psize_y, psize_x, pstride, pstride);
 }
+/*!
+ *if you want to specify kstride_y and kstride_x
+ */
+template<typename SrcExp, typename DType, int dstdim, int etype>
+inline PackColToPatchXExp<SrcExp, DType, dstdim>
+pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
+               Shape<dstdim> imshape, index_t psize_y,
+               index_t psize_x, index_t pstride_y, index_t pstride_x) {
+  TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>
+      ::Error_Expression_Does_Not_Meet_Dimension_Req();
+  CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
+    << "PackColToPatch:image shape smaller than patch size";
+  return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
+                                                   psize_y, psize_x, pstride_y, pstride_x);
+}
+
 //----------------------
 // Execution plan
 //----------------------
@@ -77,10 +95,10 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
  public:
   explicit Plan(const PackColToPatchXExp<SrcExp, DType, dstdim> &e)
       :src_(MakePlan(e.src_)), psize_y_(e.psize_y_),
-       psize_x_(e.psize_x_), pstride_(e.pstride_),
+       psize_x_(e.psize_x_), pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.shape_[dstdim - 3]), i_height_(e.shape_[dstdim - 2]),
-       o_height_((e.shape_[dstdim - 2]  - psize_y_) / pstride_ + 1),
-       o_width_((e.shape_[dstdim - 1]  - psize_x_) / pstride_ + 1) {
+       o_height_((e.shape_[dstdim - 2]  - psize_y_) / pstride_y_ + 1),
+       o_width_((e.shape_[dstdim - 1]  - psize_x_) / pstride_x_ + 1) {
     // note: i/o convention are same as unpack
   }
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
@@ -91,16 +109,16 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
     const index_t n = idivh / i_channel_;
     const index_t x = j;
     const index_t py_min =
-        y < psize_y_ ? 0 : (y-psize_y_ + pstride_) / pstride_;
+        y < psize_y_ ? 0 : (y-psize_y_ + pstride_y_) / pstride_y_;
     const index_t px_min =
-        x < psize_x_ ? 0 : (x-psize_x_ + pstride_) / pstride_;
-    const index_t py_max = min((y + pstride_) / pstride_, o_height_);
-    const index_t px_max = min((x + pstride_) / pstride_, o_width_);
+        x < psize_x_ ? 0 : (x-psize_x_ + pstride_x_) / pstride_x_;
+    const index_t py_max = min((y + pstride_y_) / pstride_y_, o_height_);
+    const index_t px_max = min((x + pstride_x_) / pstride_x_, o_width_);
     DType res = static_cast<DType>(0);
     for (index_t py = py_min; py < py_max; ++py) {
       for (index_t px = px_min; px < px_max; ++px) {
-        res += src_.Eval(((c * psize_y_ + y - py*pstride_) * psize_x_ +
-                          x - px * pstride_),
+        res += src_.Eval(((c * psize_y_ + y - py*pstride_y_) * psize_x_ +
+                          x - px * pstride_x_),
                          (n * o_height_ + py) * o_width_ + px);
       }
     }
@@ -109,7 +127,7 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
 
  private:
   Plan<SrcExp, DType> src_;
-  const index_t psize_y_, psize_x_, pstride_, i_channel_;
+  const index_t psize_y_, psize_x_, pstride_y_, pstride_x_, i_channel_;
   const index_t i_height_, o_height_, o_width_;
 };
 }  // namespace expr

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -42,7 +42,7 @@ struct UnpackPatchToColXExp:
                        index_t psize_x,
                        index_t pstride_y,
                        index_t pstride_x)
-      : img_(img), psize_y_(psize_y), psize_x_(psize_x), 
+      : img_(img), psize_y_(psize_y), psize_x_(psize_x),
       pstride_y_(pstride_y), pstride_x_(pstride_x) {
     Shape<srcdim> imshape = ShapeCheck<srcdim, SrcExp>::Check(img_);
     CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -42,7 +42,8 @@ struct UnpackPatchToColXExp:
                        index_t psize_x,
                        index_t pstride_y,
                        index_t pstride_x)
-      : img_(img), psize_y_(psize_y), psize_x_(psize_x), pstride_y_(pstride_y), pstride_x_(pstride_x) {
+      : img_(img), psize_y_(psize_y), psize_x_(psize_x), 
+      pstride_y_(pstride_y), pstride_x_(pstride_x) {
     Shape<srcdim> imshape = ShapeCheck<srcdim, SrcExp>::Check(img_);
     CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)
       << "UnpackPatchToCol:image shape smaller than patch size";
@@ -106,7 +107,7 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
  public:
   explicit Plan(const UnpackPatchToColXExp<SrcExp, DType, srcdim> &e)
       :src_(MakePlan(e.img_)),
-       psize_y_(e.psize_y_), psize_x_(e.psize_x_), 
+       psize_y_(e.psize_y_), psize_x_(e.psize_x_),
        pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.i_channel_), i_height_(e.i_height_), i_width_(e.i_width_),
        o_height_((i_height_  - psize_y_) / pstride_y_ + 1),

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -28,7 +28,8 @@ struct UnpackPatchToColXExp:
   /*! \brief patch width */
   index_t psize_x_;
   /*! \brief patch stride */
-  index_t pstride_;
+  index_t pstride_y_;
+  index_t pstride_x_;
   /*! \brief number of input channel */
   index_t i_channel_;
   /*! \brief height of img */
@@ -39,9 +40,9 @@ struct UnpackPatchToColXExp:
   UnpackPatchToColXExp(const SrcExp &img,
                        index_t psize_y,
                        index_t psize_x,
-                       index_t pstride)
-      : img_(img), psize_y_(psize_y),
-       psize_x_(psize_x), pstride_(pstride) {
+                       index_t pstride_y,
+                       index_t pstride_x)
+      : img_(img), psize_y_(psize_y), psize_x_(psize_x), pstride_y_(pstride_y), pstride_x_(pstride_x) {
     Shape<srcdim> imshape = ShapeCheck<srcdim, SrcExp>::Check(img_);
     CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)
       << "UnpackPatchToCol:image shape smaller than patch size";
@@ -50,8 +51,8 @@ struct UnpackPatchToColXExp:
     this->i_width_   = imshape[srcdim - 1];
     // calculate number of batches
     const index_t num = imshape.ProdShape(0, srcdim - 3);
-    const index_t o_height = (i_height_ - psize_y) / pstride + 1;
-    const index_t o_width  = (i_width_  - psize_x) / pstride + 1;
+    const index_t o_height = (i_height_ - psize_y) / pstride_y + 1;
+    const index_t o_width  = (i_width_  - psize_x) / pstride_x + 1;
     this->shape_[1] = o_height * o_width * num;
     this->shape_[0] = psize_y * psize_x * i_channel_;
   }
@@ -82,7 +83,20 @@ unpack_patch2col(const Exp<SrcExp, DType, etype> &img,
   TypeCheckPass<ExpInfo<SrcExp>::kDim >= 3>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   return UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
-      (img.self(), psize_y, psize_x, pstride);
+      (img.self(), psize_y, psize_x, pstride, pstride);
+}
+
+/*!
+ *if you want to specify stride_x and stride_y
+ */
+template<typename SrcExp, typename DType, int etype>
+inline UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
+unpack_patch2col(const Exp<SrcExp, DType, etype> &img,
+                 index_t psize_y, index_t psize_x, index_t pstride_y_, index_t pstride_x_) {
+  TypeCheckPass<ExpInfo<SrcExp>::kDim >= 3>
+      ::Error_Expression_Does_Not_Meet_Dimension_Req();
+  return UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
+      (img.self(), psize_y, psize_x, pstride_y_, pstride_x_);
 }
 //----------------------
 // Execution plan
@@ -92,18 +106,19 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
  public:
   explicit Plan(const UnpackPatchToColXExp<SrcExp, DType, srcdim> &e)
       :src_(MakePlan(e.img_)),
-       psize_y_(e.psize_y_), psize_x_(e.psize_x_), pstride_(e.pstride_),
+       psize_y_(e.psize_y_), psize_x_(e.psize_x_), 
+       pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.i_channel_), i_height_(e.i_height_), i_width_(e.i_width_),
-       o_height_((i_height_  - psize_y_) / pstride_ + 1),
-       o_width_((i_width_   - psize_x_) / pstride_ + 1) {}
+       o_height_((i_height_  - psize_y_) / pstride_y_ + 1),
+       o_width_((i_width_   - psize_x_) / pstride_x_ + 1) {}
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
     const index_t x_offset = i % psize_x_;
     const index_t idivp    = i / psize_x_;
     const index_t y_offset = idivp % psize_y_;
     const index_t c = idivp / psize_y_;
-    const index_t x = (j % o_width_) * pstride_ + x_offset;
+    const index_t x = (j % o_width_) * pstride_x_ + x_offset;
     const index_t jdivw = j / o_width_;
-    const index_t y = (jdivw % o_height_) * pstride_ + y_offset;
+    const index_t y = (jdivw % o_height_) * pstride_y_ + y_offset;
     const index_t n = jdivw / o_height_;
     if (x < i_width_ && y < i_height_) {
       return src_.Eval((n * i_channel_  + c) * i_height_ + y, x);
@@ -114,7 +129,7 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
 
  private:
   Plan<SrcExp, DType> src_;
-  const index_t psize_y_, psize_x_, pstride_, i_channel_;
+  const index_t psize_y_, psize_x_, pstride_y_, pstride_x_, i_channel_;
   const index_t i_height_, i_width_, o_height_, o_width_;
 };
 }  // namespace expr


### PR DESCRIPTION
`pack` and `unpack` function: replace stride with stride_x_ and stride_y_ for more flexible configuration without changing the origin method's interface
