### PR TITLE
[RFC] add ignore-label for image segmentation

### DIFF
--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -302,6 +302,31 @@ inline void SoftmaxGrad(Tensor<cpu, 3, DType> dst,
 }
 
 template<typename DType>
+inline void SoftmaxGrad(Tensor<cpu, 3, DType> dst,
+                        const Tensor<cpu, 3, DType> &src,
+                        const Tensor<cpu, 2, DType> &label,
+                        const DType &ignore_label) {
+  for (index_t n = 0; n < dst.size(2); ++n) {
+    for (index_t y = 0; y < dst.size(0); ++y) {
+      const index_t k = static_cast<int>(label[y][n]);
+      if (k == static_cast<int>(ignore_label)) {
+        for (index_t x = 0; x < dst.size(1); ++x) {
+          dst[y][x][n] = 0.0f;
+        }
+      } else {
+        for (index_t x = 0; x < dst.size(1); ++x) {
+          if (x == k) {
+            dst[y][k][n] = src[y][k][n] - 1.0f;
+          } else {
+            dst[y][x][n] = src[y][x][n];
+          }
+        }
+      }
+    }
+  }
+}
+
+template<typename DType>
 inline void Softmax(Tensor<cpu, 2, DType> dst,
                     const Tensor<cpu, 2, DType> &energy) {
   CHECK_EQ(dst.shape_, energy.shape_) << "Softmax: shape mismatch";

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -179,6 +179,14 @@ inline void SoftmaxGrad(Tensor<gpu, 3, DType> dst,
   cuda::SoftmaxGrad(dst, src, label);
 }
 
+template<typename DType>
+inline void SoftmaxGrad(Tensor<gpu, 3, DType> dst,
+                        const Tensor<gpu, 3, DType> &src,
+                        const Tensor<gpu, 2, DType> &label,
+                        const DType &ignore_label) {
+  cuda::SoftmaxGrad(dst, src, label, ignore_label);
+}
+
 }  // namespace mshadow
 #endif  // __CUDACC__
 #endif  // MSHADOW_TENSOR_GPU_INL_H_


### PR DESCRIPTION
hello,
   i have refactored the example fcn-xs in https://github.com/tornadomeet/mxnet/tree/seg/example/fcn-xs, and in image segmentation, the label image is like this http://host.robots.ox.ac.uk/pascal/VOC/voc2012/segexamples/index.html
as you can see, the index 255 corresponds to 'void' or unlabelled for ambiguity in the edge of object, so i add one SoftmaxGrad function for this problem, i just follow the caffe implentation https://github.com/longjon/caffe/blob/future/src/caffe/layers/softmax_loss_layer.cpp#L103
and we can debat this, maybe there is a better way do it.
thanks~
