### PR TITLE
add dilate option for convolution

### DIFF
--- a/mshadow/extension/pack_col2patch.h
+++ b/mshadow/extension/pack_col2patch.h
@@ -31,14 +31,22 @@ struct PackColToPatchXExp:
   /*! \brief patch stride */
   index_t pstride_y_;
   index_t pstride_x_;
+  /*! \brief patch dilate */
+  index_t pdilate_y_;
+  index_t pdilate_x_;
   /*! \brief constructor */
   PackColToPatchXExp(const SrcExp &src, Shape<dstdim> imshape,
-                     index_t psize_y, index_t psize_x, index_t pstride_y, index_t pstride_x)
+                     index_t psize_y, index_t psize_x,
+                     index_t pstride_y, index_t pstride_x,
+                     index_t pdilate_y, index_t pdilate_x)
       :src_(src), psize_y_(psize_y), psize_x_(psize_x),
-       pstride_y_(pstride_y), pstride_x_(pstride_x){
+       pstride_y_(pstride_y), pstride_x_(pstride_x),
+       pdilate_y_(pdilate_y), pdilate_x_(pdilate_x){
     this->shape_ = imshape;
-    const index_t o_height = (imshape[dstdim - 2] - psize_y) / pstride_y + 1;
-    const index_t o_width  = (imshape[dstdim - 1] - psize_x) / pstride_x + 1;
+    const index_t o_height = (imshape[dstdim - 2] -
+        (pdilate_y == 1 ? psize_y : psize_y * pdilate_y - 1)) / pstride_y + 1;
+    const index_t o_width  = (imshape[dstdim - 1] -
+        (pdilate_x == 1 ? psize_x : psize_x * pdilate_x - 1)) / pstride_x + 1;
     Shape<2> sshape = ShapeCheck<2, SrcExp>::Check(src_);
     CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
       << "PackColToPatchExp: src.size(1) mismatch";
@@ -63,13 +71,14 @@ template<typename SrcExp, typename DType, int dstdim, int etype>
 inline PackColToPatchXExp<SrcExp, DType, dstdim>
 pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
                Shape<dstdim> imshape, index_t psize_y,
-               index_t psize_x, index_t pstride) {
+               index_t psize_x, index_t pstride, index_t pdilate) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
     << "PackColToPatch:image shape smaller than patch size";
   return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
-                                                   psize_y, psize_x, pstride, pstride);
+                                                   psize_y, psize_x, pstride, pstride,
+                                                   pdilate, pdilate);
 }
 /*!
  *if you want to specify kstride_y and kstride_x
@@ -78,13 +87,15 @@ template<typename SrcExp, typename DType, int dstdim, int etype>
 inline PackColToPatchXExp<SrcExp, DType, dstdim>
 pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
                Shape<dstdim> imshape, index_t psize_y,
-               index_t psize_x, index_t pstride_y, index_t pstride_x) {
+               index_t psize_x, index_t pstride_y, index_t pstride_x,
+               index_t pdilate_y, index_t pdilate_x) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
     << "PackColToPatch:image shape smaller than patch size";
   return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
-                                                   psize_y, psize_x, pstride_y, pstride_x);
+                                                   psize_y, psize_x, pstride_y, pstride_x,
+                                                   pdilate_y, pdilate_x);
 }
 
 //----------------------
@@ -96,9 +107,12 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
   explicit Plan(const PackColToPatchXExp<SrcExp, DType, dstdim> &e)
       :src_(MakePlan(e.src_)), psize_y_(e.psize_y_),
        psize_x_(e.psize_x_), pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
-       i_channel_(e.shape_[dstdim - 3]), i_height_(e.shape_[dstdim - 2]),
-       o_height_((e.shape_[dstdim - 2]  - psize_y_) / pstride_y_ + 1),
-       o_width_((e.shape_[dstdim - 1]  - psize_x_) / pstride_x_ + 1) {
+       i_channel_(e.shape_[dstdim - 3]), pdilate_y_(e.pdilate_y_), pdilate_x_(e.pdilate_x_),
+       i_height_(e.shape_[dstdim - 2]),
+       o_height_((e.shape_[dstdim - 2]  - (pdilate_y_ == 1 ?
+           psize_y_ : psize_y_ * pdilate_y_ - 1)) / pstride_y_ + 1),
+       o_width_((e.shape_[dstdim - 1]  - (pdilate_x_ == 1 ?
+           psize_x_ : psize_x_ * pdilate_x_ - 1)) / pstride_x_ + 1) {
     // note: i/o convention are same as unpack
   }
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
@@ -108,17 +122,21 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
     const index_t c = idivh % i_channel_;
     const index_t n = idivh / i_channel_;
     const index_t x = j;
+
+    const index_t psize_y_dilate = (pdilate_y_ == 1 ? psize_y_ : psize_y_ * pdilate_y_ - 1);
+    const index_t psize_x_dilate = (pdilate_x_ == 1 ? psize_x_ : psize_x_ * pdilate_x_ - 1);
+
     const index_t py_min =
-        y < psize_y_ ? 0 : (y-psize_y_ + pstride_y_) / pstride_y_;
+        y < psize_y_dilate ? y % pdilate_y_ : (y-psize_y_dilate + pstride_y_) / pstride_y_;
     const index_t px_min =
-        x < psize_x_ ? 0 : (x-psize_x_ + pstride_x_) / pstride_x_;
+        x < psize_x_dilate ? x % pdilate_x_ : (x-psize_x_dilate + pstride_x_) / pstride_x_;
     const index_t py_max = min((y + pstride_y_) / pstride_y_, o_height_);
     const index_t px_max = min((x + pstride_x_) / pstride_x_, o_width_);
     DType res = static_cast<DType>(0);
-    for (index_t py = py_min; py < py_max; ++py) {
-      for (index_t px = px_min; px < px_max; ++px) {
-        res += src_.Eval(((c * psize_y_ + y - py*pstride_y_) * psize_x_ +
-                          x - px * pstride_x_),
+    for (index_t py = py_min; py < py_max; py += pdilate_y_) {
+      for (index_t px = px_min; px < px_max; px += pdilate_x_) {
+        res += src_.Eval(((c * psize_y_ + (y - py*pstride_y_) / pdilate_y_) * psize_x_ +
+                         (x - px * pstride_x_) / pdilate_x_),
                          (n * o_height_ + py) * o_width_ + px);
       }
     }
@@ -128,6 +146,7 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
  private:
   Plan<SrcExp, DType> src_;
   const index_t psize_y_, psize_x_, pstride_y_, pstride_x_, i_channel_;
+  const index_t pdilate_y_, pdilate_x_;
   const index_t i_height_, o_height_, o_width_;
 };
 }  // namespace expr

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -30,6 +30,9 @@ struct UnpackPatchToColXExp:
   /*! \brief patch stride */
   index_t pstride_y_;
   index_t pstride_x_;
+  /*! \brief patch dilate */
+  index_t pdilate_y_;
+  index_t pdilate_x_;
   /*! \brief number of input channel */
   index_t i_channel_;
   /*! \brief height of img */
@@ -41,9 +44,12 @@ struct UnpackPatchToColXExp:
                        index_t psize_y,
                        index_t psize_x,
                        index_t pstride_y,
-                       index_t pstride_x)
+                       index_t pstride_x,
+                       index_t pdilate_y,
+                       index_t pdilate_x)
       : img_(img), psize_y_(psize_y), psize_x_(psize_x),
-      pstride_y_(pstride_y), pstride_x_(pstride_x) {
+      pstride_y_(pstride_y), pstride_x_(pstride_x),
+      pdilate_y_(pdilate_y), pdilate_x_(pdilate_x){
     Shape<srcdim> imshape = ShapeCheck<srcdim, SrcExp>::Check(img_);
     CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)
       << "UnpackPatchToCol:image shape smaller than patch size";
@@ -52,8 +58,10 @@ struct UnpackPatchToColXExp:
     this->i_width_   = imshape[srcdim - 1];
     // calculate number of batches
     const index_t num = imshape.ProdShape(0, srcdim - 3);
-    const index_t o_height = (i_height_ - psize_y) / pstride_y + 1;
-    const index_t o_width  = (i_width_  - psize_x) / pstride_x + 1;
+    const index_t o_height = (i_height_ -
+        (pdilate_y == 1 ? psize_y : psize_y * pdilate_y - 1)) / pstride_y + 1;
+    const index_t o_width  = (i_width_  -
+        (pdilate_x == 1 ? psize_x : psize_x * pdilate_x - 1)) / pstride_x + 1;
     this->shape_[1] = o_height * o_width * num;
     this->shape_[0] = psize_y * psize_x * i_channel_;
   }
@@ -73,6 +81,7 @@ struct UnpackPatchToColXExp:
  * \param psize_y height of each patch
  * \param psize_x width of each patch
  * \param pstride stride of each patch
+ * \param pdilate dilate of each patch
  * \tparam SrcExp source expression
  * \tparam DType the type of elements
  * \tparam etype type of expression
@@ -80,11 +89,11 @@ struct UnpackPatchToColXExp:
 template<typename SrcExp, typename DType, int etype>
 inline UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
 unpack_patch2col(const Exp<SrcExp, DType, etype> &img,
-                 index_t psize_y, index_t psize_x, index_t pstride) {
+                 index_t psize_y, index_t psize_x, index_t pstride, index_t pdilate) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim >= 3>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   return UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
-      (img.self(), psize_y, psize_x, pstride, pstride);
+      (img.self(), psize_y, psize_x, pstride, pstride, pdilate, pdilate);
 }
 
 /*!
@@ -93,11 +102,12 @@ unpack_patch2col(const Exp<SrcExp, DType, etype> &img,
 template<typename SrcExp, typename DType, int etype>
 inline UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
 unpack_patch2col(const Exp<SrcExp, DType, etype> &img,
-                 index_t psize_y, index_t psize_x, index_t pstride_y_, index_t pstride_x_) {
+                 index_t psize_y, index_t psize_x, index_t pstride_y_, index_t pstride_x_,
+                 index_t pdilate_y_, index_t pdilate_x_) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim >= 3>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   return UnpackPatchToColXExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
-      (img.self(), psize_y, psize_x, pstride_y_, pstride_x_);
+      (img.self(), psize_y, psize_x, pstride_y_, pstride_x_, pdilate_y_, pdilate_x_);
 }
 //----------------------
 // Execution plan
@@ -109,13 +119,16 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
       :src_(MakePlan(e.img_)),
        psize_y_(e.psize_y_), psize_x_(e.psize_x_),
        pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
-       i_channel_(e.i_channel_), i_height_(e.i_height_), i_width_(e.i_width_),
-       o_height_((i_height_  - psize_y_) / pstride_y_ + 1),
-       o_width_((i_width_   - psize_x_) / pstride_x_ + 1) {}
+       i_channel_(e.i_channel_), pdilate_y_(e.pdilate_y_), pdilate_x_(e.pdilate_x_),
+       i_height_(e.i_height_), i_width_(e.i_width_),
+       o_height_((i_height_  - (pdilate_y_ == 1 ?
+           psize_y_ : psize_y_ * pdilate_y_ - 1)) / pstride_y_ + 1),
+       o_width_((i_width_   - (pdilate_x_ == 1 ?
+           psize_x_ : psize_x_ * pdilate_x_ - 1)) / pstride_x_ + 1) {}
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
-    const index_t x_offset = i % psize_x_;
+    const index_t x_offset = i % psize_x_ * pdilate_x_;
     const index_t idivp    = i / psize_x_;
-    const index_t y_offset = idivp % psize_y_;
+    const index_t y_offset = idivp % psize_y_ * pdilate_y_;
     const index_t c = idivp / psize_y_;
     const index_t x = (j % o_width_) * pstride_x_ + x_offset;
     const index_t jdivw = j / o_width_;
@@ -131,6 +144,7 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
  private:
   Plan<SrcExp, DType> src_;
   const index_t psize_y_, psize_x_, pstride_y_, pstride_x_, i_channel_;
+  const index_t pdilate_y_, pdilate_x_;
   const index_t i_height_, i_width_, o_height_, o_width_;
 };
 }  // namespace expr


### PR DESCRIPTION
Add dilate option for convolution, used for semantic segmentation.

Detail could be found in the following paper and their code.

Semantic Image Segmentation with Deep Convolutional Nets and Fully Connected CRFs.
Liang-Chieh Chen_, George Papandreou_, Iasonas Kokkinos, Kevin Murphy, and Alan L. Yuille
ICLR 2015
