### PR TITLE
Change names of mshadow's internal logger

### DIFF
--- a/mshadow-ps/mshadow_ps.h
+++ b/mshadow-ps/mshadow_ps.h
@@ -303,7 +303,7 @@ class IModelUpdater {
    * \param data the tensor data corresponding to the data we want to initialize
    */
   virtual void InitModel_(int key, Tensor<cpu, 1, DType> data) {
-    LOG(FATAL) << "InitModel: not implemented";
+    MSHADOW_LOG(FATAL) << "InitModel: not implemented";
   }
   /*!
    * \brief update the model, user can implement this one
@@ -312,7 +312,7 @@ class IModelUpdater {
    * \param data the tensor data corresponding to the data we want to initialize
    */
   virtual void Update_(int key, Tensor<cpu, 1, DType> data) {
-    LOG(FATAL) << "InitModel: not implemented";
+    MSHADOW_LOG(FATAL) << "InitModel: not implemented";
   }
 };
 /*!
@@ -350,7 +350,7 @@ inline ISharedModel<xpu, DType> *CreateSharedModel(const char *type) {
 #if MSHADOW_DIST_PS
   if (!strcmp("dist", type)) return new DistModel<xpu, DType>();
 #endif
-  LOG(FATAL) << "unknown server type " << type;
+  MSHADOW_LOG(FATAL) << "unknown server type " << type;
   return NULL;
 }
 }  // namespace ps

--- a/mshadow-ps/ps_dist-inl.h
+++ b/mshadow-ps/ps_dist-inl.h
@@ -81,7 +81,7 @@ class DistModel : public LocalModel<xpu, DType> {
 
     // push and pull
     Tensor<cpu, 2> sendrecv = data[0];
-    CHECK_EQ(data[0].CheckContiguous(), true) << "data must be contiguous";
+    MSHADOW_CHECK_EQ(data[0].CheckContiguous(), true) << "data must be contiguous";
 
     int ts = shared_model_.Push(
         ::ps::Parameter::Request(key), sendrecv.dptr_, sendrecv.MSize(), false);

--- a/mshadow-ps/ps_rabit-inl.h
+++ b/mshadow-ps/ps_rabit-inl.h
@@ -60,7 +60,7 @@ class RabitModel : public LocalModel<xpu, DType> {
                                 int key) {
     // summation the data fron all devices
     LocalModel<xpu, DType>::ReduceSum(data);
-    CHECK_EQ(data[0].CheckContiguous(), true) << "data must be contiguous";
+    MSHADOW_CHECK_EQ(data[0].CheckContiguous(), true) << "data must be contiguous";
     ReduceTask tsk;
     tsk.data = data[0]; tsk.key = key;
     reduce_queue_.Push(tsk, 0);
@@ -87,17 +87,17 @@ class RabitModel : public LocalModel<xpu, DType> {
     while (!destroy_reduce_thread_) {
       ReduceTask tsk;
       if (reduce_queue_.Pop(&tsk)) {
-        CHECK_EQ(disable_allreduce_, 0) << "Allreduce disabled error";
+        MSHADOW_CHECK_EQ(disable_allreduce_, 0) << "Allreduce disabled error";
         int key = tsk.key;
         rabit::Allreduce<rabit::op::Max>(&key, 1);
-        CHECK_EQ(key, tsk.key) << "Allreduce not concensus";
+        MSHADOW_CHECK_EQ(key, tsk.key) << "Allreduce not concensus";
         rabit::Allreduce<rabit::op::Sum>
             (tsk.data.dptr_, tsk.data.MSize());
         tsk.data *= 1.0f / rabit::GetWorldSize();
-        CHECK_EQ(disable_allreduce_, 0) << "Allreduce disabled error";
+        MSHADOW_CHECK_EQ(disable_allreduce_, 0) << "Allreduce disabled error";
         this->HandleReduceFinish(tsk.data, tsk.key);
       } else {
-        CHECK_EQ(destroy_reduce_thread_, true) << "abort but not destroy";
+        MSHADOW_CHECK_EQ(destroy_reduce_thread_, true) << "abort but not destroy";
       }
     }
   }

--- a/mshadow-ps/thread.h
+++ b/mshadow-ps/thread.h
@@ -19,17 +19,17 @@ class Semaphore {
  public :
   inline void Init(int init_val) {
     sem = CreateSemaphore(NULL, init_val, 10, NULL);
-    CHECK_NE(sem, NULL) << "create Semaphore error";
+    MSHADOW_CHECK_NE(sem, NULL) << "create Semaphore error";
   }
   inline void Destroy(void) {
     CloseHandle(sem);
   }
   inline void Wait(void) {
-    CHECK_EQ(WaitForSingleObject(sem, INFINITE), WAIT_OBJECT_0)
+    MSHADOW_CHECK_EQ(WaitForSingleObject(sem, INFINITE), WAIT_OBJECT_0)
       << "WaitForSingleObject error";
   }
   inline void Post(void) {
-    CHECK_NE(ReleaseSemaphore(sem, 1, NULL), 0) << "ReleaseSemaphore error";
+    MSHADOW_CHECK_NE(ReleaseSemaphore(sem, 1, NULL), 0) << "ReleaseSemaphore error";
   }
 
  private:
@@ -40,7 +40,7 @@ class Semaphore {
 class Mutex {
  public:
   inline void Init(void) {
-    CHECK_NE(InitializeCriticalSectionAndSpinCount(&mutex, 0x00000400), 0)
+    MSHADOW_CHECK_NE(InitializeCriticalSectionAndSpinCount(&mutex, 0x00000400), 0)
       << "Mutex::Init fail";
   }
   inline void Lock(void) {
@@ -71,7 +71,7 @@ class ConditionVariable {
   }
   // wait on the conditional variable
   inline void Wait(Mutex *mutex) {
-    CHECK_NE(SleepConditionVariableCS(&cond, &(mutex->mutex), INFINITE), 0)
+    MSHADOW_CHECK_NE(SleepConditionVariableCS(&cond, &(mutex->mutex), INFINITE), 0)
       << "ConditionVariable:Wait fail";
   }
   inline void Broadcast(void) {
@@ -141,7 +141,7 @@ class Semaphore {
       perror("sem_open");
       exit(1);
     }
-    CHECK_NE(semPtr, NULL) << "create Semaphore error";
+    MSHADOW_CHECK_NE(semPtr, NULL) << "create Semaphore error";
   }
   inline void Destroy(void) {
     if (sem_close(semPtr) == -1) {
@@ -167,22 +167,22 @@ class Semaphore {
  public:
   inline void Init(int init_val) {
     if (sem_init(&sem, 0, init_val) != 0) {
-      LOG(FATAL) << "Semaphore.Init: " << strerror(errno);
+      MSHADOW_LOG(FATAL) << "Semaphore.Init: " << strerror(errno);
     }
   }
   inline void Destroy(void) {
     if (sem_destroy(&sem) != 0) {
-      LOG(FATAL) << "Semaphore.Destroy: " << strerror(errno);
+      MSHADOW_LOG(FATAL) << "Semaphore.Destroy: " << strerror(errno);
     }
   }
   inline void Wait(void) {
     if (sem_wait(&sem) != 0) {
-      LOG(FATAL) << "Semaphore.Wait: " << strerror(errno);
+      MSHADOW_LOG(FATAL) << "Semaphore.Wait: " << strerror(errno);
     }
   }
   inline void Post(void) {
     if (sem_post(&sem) != 0) {
-      LOG(FATAL) << "Semaphore.Post: " << strerror(errno);
+      MSHADOW_LOG(FATAL) << "Semaphore.Post: " << strerror(errno);
     }
   }
   #endif

--- a/mshadow-ps/thread_util.h
+++ b/mshadow-ps/thread_util.h
@@ -83,11 +83,11 @@ class ThreadPQueue {
       }
     }
     if (use_fifo_) {
-      CHECK_NE(fqueue_.size(), 0) << "Queue.Pop";
+      MSHADOW_CHECK_NE(fqueue_.size(), 0) << "Queue.Pop";
       *data_out = fqueue_.front();
       fqueue_.pop();
     } else {
-      CHECK_NE(pqueue_.size(), 0) << "Queue.Pop";
+      MSHADOW_CHECK_NE(pqueue_.size(), 0) << "Queue.Pop";
       *data_out = pqueue_.top().data;
       pqueue_.pop();
     }
@@ -147,7 +147,7 @@ class ThreadSafeMap {
   }
   inline TValue &GetRef(int key) {
     TValue *ret = this->Get(key);
-    CHECK_NE(ret, NULL) << "key = " << key << " does not exist";
+    MSHADOW_CHECK_NE(ret, NULL) << "key = " << key << " does not exist";
     return *ret;
   }
   inline void Init(int key) {

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -192,7 +192,7 @@ extern "C" {
     if (e == cudaErrorCudartUnloading) {                           \
       throw dmlc::Error(cudaGetErrorString(e));                    \
     }                                                              \
-    CHECK(e == cudaSuccess)                                        \
+    MSHADOW_CHECK(e == cudaSuccess)                                        \
         << "CUDA: " << cudaGetErrorString(e);                      \
   }
 

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -207,7 +207,7 @@ extern "C" {
   {                                                                \
     cudaError_t e = (func);                                        \
     if (e == cudaErrorCudartUnloading) {                           \
-      throw dmlc::Error(cudaGetErrorString(e));                    \
+      throw mshadow::Error(cudaGetErrorString(e));                    \
     }                                                              \
     MSHADOW_CHECK(e == cudaSuccess)                                        \
         << "CUDA: " << cudaGetErrorString(e);                      \
@@ -221,7 +221,7 @@ extern "C" {
   {                                                                   \
     try {                                                             \
       (func);                                                         \
-    } catch (const dmlc::Error &e) {                                    \
+    } catch (const mshadow::Error &e) {                                    \
       std::string what = e.what();                                      \
       if (what.find("driver shutting down") == std::string::npos) {     \
         MSHADOW_LOG(ERROR) << "Ignore CUDA Error " << what;                     \

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -224,7 +224,7 @@ extern "C" {
     } catch (const dmlc::Error &e) {                                    \
       std::string what = e.what();                                      \
       if (what.find("driver shutting down") == std::string::npos) {     \
-        LOG(ERROR) << "Ignore CUDA Error " << what;                     \
+        MSHADOW_LOG(ERROR) << "Ignore CUDA Error " << what;                     \
       }                                                                 \
     }                                                                   \
   }

--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -398,9 +398,9 @@ inline void SoftmaxGrad(Tensor<gpu, 3, DType> &dst,
                         const DType &ignore_label) {
   dim3 dimBlock(kBaseThreadNum);
   dim3 dimGrid(dst.size(0));
-  CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
-  CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
-  CHECK_EQ(dst.size(2), label.size(1)) << "SoftmaxGrad: label shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
+  MSHADOW_CHECK_EQ(dst.size(2), label.size(1)) << "SoftmaxGrad: label shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "SoftmaxGrad");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
   Softmax3DGradKernel<kBaseThreadBits, DType><<<dimGrid, dimBlock, 0, stream>>>(dst, src, label, ignore_label);

--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -43,7 +43,7 @@ inline index_t GetAlignStride(index_t xsize) {
 inline void CheckLaunchParam(dim3 dimGrid, dim3 dimBlock, const char *estr = "") {
   if (dimBlock.x * dimBlock.y * dimBlock.z > static_cast<unsigned>(kMaxThreadsPerBlock) ||
       dimGrid.x > 65535 || dimGrid.y > 65535) {
-    LOG(FATAL) << "too large launch parameter: "
+    MSHADOW_LOG(FATAL) << "too large launch parameter: "
       << estr << "["
       << dimBlock.x << ","
       << dimBlock.y << ","
@@ -261,7 +261,7 @@ inline void Softmax(Tensor<gpu, 2, DType> &dst,
                     const Tensor<gpu, 2, DType> &src) {
   dim3 dimBlock(kBaseThreadNum);
   dim3 dimGrid(dst.size(0));
-  CHECK_EQ(dst.shape_, src.shape_) << "Softmax: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, src.shape_) << "Softmax: shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "Softmax");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
   SoftmaxKernel<kBaseThreadBits, DType>
@@ -277,8 +277,8 @@ inline void SoftmaxGrad(Tensor<gpu, 2, DType> &dst,
                         const Tensor<gpu, 1, DType> &label) {
   dim3 dimBlock(kBaseThreadNum);
   dim3 dimGrid(dst.size(0));
-  CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
-  CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "SoftmaxGrad");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
   SoftmaxGradKernel<kBaseThreadBits, DType>
@@ -338,7 +338,7 @@ inline void Softmax(Tensor<gpu, 3, DType> &dst,
                     const Tensor<gpu, 3, DType> &src) {
   dim3 dimBlock(kBaseThreadNum);
   dim3 dimGrid(dst.size(0));
-  CHECK_EQ(dst.shape_, src.shape_) << "Softmax: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, src.shape_) << "Softmax: shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "Softmax");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
   Softmax3DKernel<DType><<<dimGrid, dimBlock, 0, stream>>>(dst, src);
@@ -351,9 +351,9 @@ inline void SoftmaxGrad(Tensor<gpu, 3, DType> &dst,
                         const Tensor<gpu, 2, DType> &label) {
   dim3 dimBlock(kBaseThreadNum);
   dim3 dimGrid(dst.size(0));
-  CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
-  CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
-  CHECK_EQ(dst.size(2), label.size(1)) << "SoftmaxGrad: label shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, src.shape_) << "SoftmaxGrad: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.size(0), label.size(0)) << "SoftmaxGrad: label shape mismatch";
+  MSHADOW_CHECK_EQ(dst.size(2), label.size(1)) << "SoftmaxGrad: label shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "SoftmaxGrad");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
   Softmax3DGradKernel<DType><<<dimGrid, dimBlock, 0, stream>>>(dst, src, label);

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -36,27 +36,27 @@ struct BLASEngine {
                           int m, int n, int k, DType alpha,
                           const DType *A, int lda, const DType *B, int ldb,
                           DType beta, DType *C, int ldc) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void gemv(Stream<Device> *stream,
                           bool trans, int m, int n,
                           DType alpha, const DType *A, int lda,
                           const DType *X, int incX,
                           DType beta, DType *Y, int incY) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<Device> *stream,
                          int m, int n, DType alpha,
                          const DType *X, int incX,
                          const DType *Y, int incY, DType *A, int lda) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<Device> *stream,
                          int n,
                          const DType* X, int incX,
                          const DType* Y, int incY,
                          DType* ret) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
 };
 
@@ -86,10 +86,10 @@ struct BLASEngine<cpu, float> {
       } else if (transpose_left && !transpose_right) {
         dst = expr::implicit_dot(lhs.T(), rhs); return;
       } else {
-        LOG(FATAL) << "Not implmented!";
+        MSHADOW_LOG(FATAL) << "Not implmented!";
       }
     } else {
-      LOG(FATAL) << "Not implmented!";
+      MSHADOW_LOG(FATAL) << "Not implmented!";
     }
   }
   inline static void gemv(Stream<cpu> *stream,
@@ -97,20 +97,20 @@ struct BLASEngine<cpu, float> {
                           float alpha, const float *A, int lda,
                           const float *X, int incX,
                           float beta, float *Y, int incY) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
                          int m, int n, float alpha,
                          const float *X, int incX,
                          const float *Y, int incY, float *A, int lda) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
                          int n,
                          const float* X, int incX,
                          const float* Y, int incY,
                          float* ret) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
 };
 
@@ -139,10 +139,10 @@ struct BLASEngine<cpu, double> {
       } else if (transpose_left && !transpose_right) {
         dst = expr::implicit_dot(lhs.T(), rhs); return;
       } else {
-        LOG(FATAL) << "Not implmented!";
+        MSHADOW_LOG(FATAL) << "Not implmented!";
       }
     } else {
-      LOG(FATAL) << "Not implmented!";
+      MSHADOW_LOG(FATAL) << "Not implmented!";
     }
   }
   inline static void gemv(Stream<cpu> *stream,
@@ -150,20 +150,20 @@ struct BLASEngine<cpu, double> {
                           double alpha, const double *A, int lda,
                           const double *X, int incX,
                           double beta, double *Y, int incY) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
                          int m, int n, double alpha,
                          const double *X, int incX,
                          const double *Y, int incY, double *A, int lda) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
                          int n,
                          const double* X, int incX,
                          const double* Y, int incY,
                          double* ret) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
 };
 

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -105,54 +105,54 @@ struct BLASEngine<cpu> {
                           int m, int n, int k, float alpha,
                           const float *A, int lda, const float *B, int ldb,
                           float beta, float *C, int ldc) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
                           int m, int n, int k, double alpha,
                           const double *A, int lda, const double *B, int ldb,
                           double beta, double *C, int ldc) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void gemv(Stream<cpu> *stream,
                           bool trans, int m, int n,
                           float alpha, const float *A, int lda,
                           const float *X, int incX,
                           float beta, float *Y, int incY) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void gemv(Stream<cpu> *stream,
                           bool trans, int m, int n, double alpha,
                           const double *A, int lda,
                           const double *X, int incX,
                           double beta, double *Y, int incY) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
                          int m, int n, float alpha,
                          const float *X, int incX,
                          const float *Y, int incY, float *A, int lda) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
                          int m, int n, double alpha,
                          const double *X, int incX,
                          const double *Y, int incY, double *A, int lda) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
                          int n,
                          const float* X, int incX,
                          const float* Y, int incY,
                          float* ret) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
                          int n,
                          const double* X, int incX,
                          const double* Y, int incY,
                          double* ret) {
-    LOG(FATAL) << "Not implmented!";
+    MSHADOW_LOG(FATAL) << "Not implmented!";
   }
 };
 #endif  // MSHADOW_USE_CBLAS || MSHADOW_USE_MKL || MSHADOW_STAND_ALONE
@@ -167,7 +167,7 @@ struct BLASEngine<gpu> {
   inline static void SetStream(Stream<gpu> *stream) {
     cublasStatus_t err = cublasSetStream(Stream<gpu>::GetBlasHandle(stream),
                     Stream<gpu>::GetStream(stream));
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas set stream fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas set stream fail";
   }
   inline static void gemm(Stream<gpu> *stream,
                           bool transa, bool transb,
@@ -178,7 +178,7 @@ struct BLASEngine<gpu> {
     cublasStatus_t err = cublasSgemm(Stream<gpu>::GetBlasHandle(stream),
                 GetT(transa), GetT(transb), m, n, k, &alpha,
                 A, lda, B, ldb, &beta, C, ldc);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas Sgemm fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas Sgemm fail";
   }
   inline static void gemm(Stream<gpu> *stream,
                           bool transa, bool transb,
@@ -189,7 +189,7 @@ struct BLASEngine<gpu> {
     cublasStatus_t err = cublasDgemm(Stream<gpu>::GetBlasHandle(stream),
                 GetT(transa), GetT(transb), m, n, k, &alpha,
                 A, lda, B, ldb, &beta, C, ldc);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dgemm fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dgemm fail";
   }
   inline static void gemv(Stream<gpu> *stream,
                           bool trans, int m, int n, float alpha,
@@ -198,7 +198,7 @@ struct BLASEngine<gpu> {
                           float *Y, int incY) {
     cublasStatus_t err = cublasSgemv(Stream<gpu>::GetBlasHandle(stream),
                 GetT(trans), m, n, &alpha, A, lda, X, incX, &beta, Y, incY);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Sgemv fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Sgemv fail";
   }
   inline static void gemv(Stream<gpu> *stream,
                           bool trans, int m, int n, double alpha,
@@ -207,7 +207,7 @@ struct BLASEngine<gpu> {
                           double beta, double *Y, int incY) {
     cublasStatus_t err = cublasDgemv(Stream<gpu>::GetBlasHandle(stream),
                 GetT(trans), m, n, &alpha, A, lda, X, incX, &beta, Y, incY);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dgemv fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dgemv fail";
   }
   inline static void ger(Stream<gpu> *stream,
                          int m, int n, float alpha,
@@ -215,7 +215,7 @@ struct BLASEngine<gpu> {
                          const float *Y, int incY, float *A, int lda) {
     cublasStatus_t err = cublasSger(Stream<gpu>::GetBlasHandle(stream),
                                     m, n, &alpha, X, incX, Y, incY, A, lda);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Sger fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Sger fail";
   }
   inline static void ger(Stream<gpu> *stream,
                          int m, int n, double alpha,
@@ -223,7 +223,7 @@ struct BLASEngine<gpu> {
                          const double *Y, int incY, double *A, int lda) {
     cublasStatus_t err = cublasDger(Stream<gpu>::GetBlasHandle(stream),
                                     m, n, &alpha, X, incX, Y, incY, A, lda);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dger fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dger fail";
   }
   inline static void dot(Stream<gpu> *stream,
                          int n,
@@ -234,7 +234,7 @@ struct BLASEngine<gpu> {
                          CUBLAS_POINTER_MODE_DEVICE);
     cublasStatus_t err = cublasSdot(Stream<gpu>::GetBlasHandle(stream),
                                     n, X, incX, Y, incY, ret);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dot fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dot fail";
     cublasSetPointerMode(Stream<gpu>::GetBlasHandle(stream),
                          CUBLAS_POINTER_MODE_HOST);
   }
@@ -247,7 +247,7 @@ struct BLASEngine<gpu> {
                          CUBLAS_POINTER_MODE_DEVICE);
     cublasStatus_t err = cublasDdot(Stream<gpu>::GetBlasHandle(stream),
                                     n, X, incX, Y, incY, ret);
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dot fail";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: Dot fail";
     cublasSetPointerMode(Stream<gpu>::GetBlasHandle(stream),
                          CUBLAS_POINTER_MODE_HOST);
   }
@@ -282,7 +282,7 @@ struct DotEngine<SV, xpu, 2, 2, 2, transpose_left, transpose_right, DType> {
     BLASEngine<xpu>::SetStream(dst.stream_);
     Shape<2> sleft = GetShape(lhs.shape_, transpose_left);
     Shape<2> sright = GetShape(rhs.shape_, transpose_right);
-    CHECK(dst.size(0) == sleft[0] && dst.size(1) == sright[1] && sleft[1] == sright[0])
+    MSHADOW_CHECK(dst.size(0) == sleft[0] && dst.size(1) == sright[1] && sleft[1] == sright[0])
       << "dot-gemm: matrix shape mismatch";
     // use column major argument to compatible with most BLAS
     BLASEngine<xpu>::gemm
@@ -309,7 +309,7 @@ struct DotEngine<SV, xpu, 1, 1, 2, false, transpose_right, DType> {
     // if there is no stream, crush
     BLASEngine<xpu>::SetStream(dst.stream_);
     Shape<2> sright = GetShape(rhs.shape, transpose_right);
-    CHECK(dst.size(0) == sright[1] && lhs.size(0) == sright[0])
+    MSHADOW_CHECK(dst.size(0) == sright[1] && lhs.size(0) == sright[0])
       << "dot-gemv: matrix shape mismatch"
       << "dst: " << dst.shape_ << "\n"
       << "lhs: " << lhs.shape_ << "\n"
@@ -333,7 +333,7 @@ struct DotEngine<SV, xpu, 2, 1, 1, true, false, DType> {
     // set kernel stream
     // if there is no stream, crush
     BLASEngine<xpu>::SetStream(dst.stream_);
-    CHECK_EQ(dst.size(0), lhs.size(0) && dst.size(1) == rhs.size(0))
+    MSHADOW_CHECK_EQ(dst.size(0), lhs.size(0) && dst.size(1) == rhs.size(0))
       << "dot-ger: matrix shape mismatch"
       << "dst: " << dst.shape_ << "\n"
       << "lhs: " << lhs.shape_ << "\n"

--- a/mshadow/expr_engine-inl.h
+++ b/mshadow/expr_engine-inl.h
@@ -364,7 +364,7 @@ struct ShapeCheck<dim, BinaryMapExp<OP, TA, TB, DType, etype> > {
     Shape<dim> shape2 = ShapeCheck<dim, TB>::Check(t.rhs_);
     if (shape1[0] == 0) return shape2;
     if (shape2[0] == 0) return shape1;
-    CHECK_EQ(shape1, shape2) << "BinaryMapExp: Shapes of operands are not the same";
+    MSHADOW_CHECK_EQ(shape1, shape2) << "BinaryMapExp: Shapes of operands are not the same";
     return shape1;
   }
 };

--- a/mshadow/extension/broadcast.h
+++ b/mshadow/extension/broadcast.h
@@ -48,7 +48,7 @@ broadcast(const expr::Exp<SrcExp, DType, etype> &src, Shape<dimdst> shape) {
   TypeCheckPass<dimcast < dimdst && ExpInfo<SrcExp>::kDim == 1>
                 ::Error_Expression_Does_Not_Meet_Dimension_Req();
   typedef ShapeCheck<1, SrcExp> ShapeCheckDim1SrcExp;
-  CHECK_EQ(ShapeCheckDim1SrcExp::Check(src.self())[0], shape[dimcast])
+  MSHADOW_CHECK_EQ(ShapeCheckDim1SrcExp::Check(src.self())[0], shape[dimcast])
     << "broadcast, shape mismatch";
   return Broadcast1DExp<SrcExp, DType, dimdst,
                         dimdst - dimcast>(src.self(), shape);

--- a/mshadow/extension/broadcast_with_axis.h
+++ b/mshadow/extension/broadcast_with_axis.h
@@ -34,7 +34,7 @@ struct BroadcastWithAxisExp:
   /*! constructor */
   BroadcastWithAxisExp(const SrcExp &src, const int axis, const index_t size)
     : src_(src), size_(size) {
-    CHECK(srcdim > axis) << "broadcast axis out of bound";
+    MSHADOW_CHECK(srcdim > axis) << "broadcast axis out of bound";
     Shape<srcdim> src_shape = ShapeCheck<srcdim, SrcExp>::Check(src_);
     this->leading_ = 1;
     for (index_t i = 0; i <= axis; ++i) {

--- a/mshadow/extension/channel_pool.h
+++ b/mshadow/extension/channel_pool.h
@@ -36,7 +36,7 @@ struct ChannelPoolingExp:
       : src_(src), nsize_(nsize), stride_(stride), pad_(pad) {
     this->shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
     this->src_channel_ = this->shape_[srcdim - 3];
-    CHECK_GE(this->shape_[srcdim - 3], nsize_)
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 3], nsize_)
       << "chpool: local size must be smaller than nchannels";
     this->shape_[srcdim - 3] = (this->src_channel_ - nsize + pad * 2 + 1) / stride;
   }
@@ -57,7 +57,7 @@ inline ChannelPoolingExp<Reducer, SrcExp, DType, ExpInfo<SrcExp>::kDim>
 chpool(const Exp<SrcExp, DType, etype> &src, index_t nsize) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim >= 3>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
-  CHECK_EQ(nsize % 2, 1) << "chpool: if no pad is specified, local size must be odd";
+  MSHADOW_CHECK_EQ(nsize % 2, 1) << "chpool: if no pad is specified, local size must be odd";
   return ChannelPoolingExp<Reducer, SrcExp,
                            DType, ExpInfo<SrcExp>::kDim>(src.self(), nsize, 1, nsize / 2);
 }

--- a/mshadow/extension/channel_unpool.h
+++ b/mshadow/extension/channel_unpool.h
@@ -46,14 +46,14 @@ struct ChannelUnpoolingExp:
         nsize_(nsize), kstride_(kstride), pad_(pad) {
     Shape<srcdim> pshape = ShapeCheck<srcdim, SrcExp>::Check(grad_pooled);
     typedef ShapeCheck<srcdim, SrcExp> ShapeCheckSrcDimSrcExp;
-    CHECK_EQ(pshape, ShapeCheckSrcDimSrcExp::Check(data_pooled))
+    MSHADOW_CHECK_EQ(pshape, ShapeCheckSrcDimSrcExp::Check(data_pooled))
       << "ChannelUnPoolingExp: data and grad shape mismatch";
     Shape<srcdim> sshape = ShapeCheck<srcdim, SrcExp>::Check(data_src);
     for (int k = 0; k < srcdim; ++k) {
       if (k == 1) {
         continue;
       }
-      CHECK_EQ(pshape[k], sshape[k])
+      MSHADOW_CHECK_EQ(pshape[k], sshape[k])
         << "ChannelUnPoolingExp: pooled tensor and src tensor shape mismatch"
         << pshape[k]
         << " vs "

--- a/mshadow/extension/choose.h
+++ b/mshadow/extension/choose.h
@@ -70,11 +70,11 @@ template<int dim, typename SrcExp, typename IndexExp, typename DType>
 struct ShapeCheck<dim, MatChooseRowElementExp<SrcExp, IndexExp, DType> > {
   inline static Shape<dim>
   Check(const MatChooseRowElementExp<SrcExp, IndexExp, DType> &t) {
-    CHECK(dim == 1)
+    MSHADOW_CHECK(dim == 1)
         << "MatChooseRowElementExp only support 1 dimension output";
     Shape<2> shape1 = ShapeCheck<2, SrcExp>::Check(t.src_);
     Shape<dim> shape2 = ShapeCheck<dim, IndexExp>::Check(t.index_);
-    CHECK_EQ(shape1[0], shape2[0])
+    MSHADOW_CHECK_EQ(shape1[0], shape2[0])
         << "mat_choose_row_element index length and number of rows in matrix";
     return shape2;
   }

--- a/mshadow/extension/concat.h
+++ b/mshadow/extension/concat.h
@@ -37,7 +37,7 @@ struct ConcatExp : public TRValue<ConcatExp<LhsExp, RhsExp,
     #pragma unroll
     for (int i = 0; i < srcdim; ++i) {
       if (i != dimcat) {
-        CHECK_EQ(sshape1[i], sshape2[i]) << "ConcatExp: shape mismatch";
+        MSHADOW_CHECK_EQ(sshape1[i], sshape2[i]) << "ConcatExp: shape mismatch";
       }
     }
     this->shape_ = sshape1;

--- a/mshadow/extension/crop.h
+++ b/mshadow/extension/crop.h
@@ -31,8 +31,10 @@ struct CroppingExp:
   explicit CroppingExp(const SrcExp &src, Shape<2> cshape)
       : src_(src) {
     this->shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
-    MSHADOW_CHECK_GE(this->shape_[srcdim - 2], cshape[0]) << "CroppingExp: height requirement not met";
-    MSHADOW_CHECK_GE(this->shape_[srcdim - 1], cshape[1]) << "CroppingExp: width requirement not met";
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 2], cshape[0])
+      << "CroppingExp: height requirement not met";
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 1], cshape[1])
+      << "CroppingExp: width requirement not met";
     pad_height_ = (this->shape_[srcdim - 2] - cshape[0]) / 2;
     pad_width_ = (this->shape_[srcdim - 1] - cshape[1]) / 2;
     src_height_ = this->shape_[srcdim - 2];

--- a/mshadow/extension/crop.h
+++ b/mshadow/extension/crop.h
@@ -31,8 +31,8 @@ struct CroppingExp:
   explicit CroppingExp(const SrcExp &src, Shape<2> cshape)
       : src_(src) {
     this->shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
-    CHECK_GE(this->shape_[srcdim - 2], cshape[0]) << "CroppingExp: height requirement not met";
-    CHECK_GE(this->shape_[srcdim - 1], cshape[1]) << "CroppingExp: width requirement not met";
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 2], cshape[0]) << "CroppingExp: height requirement not met";
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 1], cshape[1]) << "CroppingExp: width requirement not met";
     pad_height_ = (this->shape_[srcdim - 2] - cshape[0]) / 2;
     pad_width_ = (this->shape_[srcdim - 1] - cshape[1]) / 2;
     src_height_ = this->shape_[srcdim - 2];
@@ -44,9 +44,9 @@ struct CroppingExp:
                        index_t start_height, index_t start_width)
       : src_(src), pad_height_(start_height), pad_width_(start_width) {
     this->shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
-    CHECK_GE(this->shape_[srcdim - 2], cshape[0] + start_height)
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 2], cshape[0] + start_height)
       << "CroppingExp: height requirement not met";
-    CHECK_GE(this->shape_[srcdim - 1], cshape[1] + start_width)
+    MSHADOW_CHECK_GE(this->shape_[srcdim - 1], cshape[1] + start_width)
       << "CroppingExp: width requirement not met";
     src_height_ = this->shape_[srcdim - 2];
     this->shape_[srcdim - 2] = cshape[0];  // height

--- a/mshadow/extension/fill.h
+++ b/mshadow/extension/fill.h
@@ -81,12 +81,12 @@ template<int dim, typename SrcExp, typename ValExp, typename IndexExp, typename 
 struct ShapeCheck<dim, MatFillRowElementExp<SrcExp, ValExp, IndexExp, DType> > {
   inline static Shape<dim>
   Check(const MatFillRowElementExp<SrcExp, ValExp, IndexExp, DType> &t) {
-    CHECK(dim == 2)
+    MSHADOW_CHECK(dim == 2)
         << "MatFillRowElementExp only support 2 dimension output";
     Shape<2> shape_src = ShapeCheck<2, SrcExp>::Check(t.src_);
     Shape<1> shape_val = ShapeCheck<1, ValExp>::Check(t.val_);
     Shape<1> shape_index = ShapeCheck<1, IndexExp>::Check(t.index_);
-    CHECK((shape_src[0] == shape_index[0]) && (shape_index[0] == shape_val[0]))
+    MSHADOW_CHECK((shape_src[0] == shape_index[0]) && (shape_index[0] == shape_val[0]))
         << "mat_fill_row_element index length, val length and number of rows in matrix";
     return shape_src;
   }

--- a/mshadow/extension/implicit_gemm.h
+++ b/mshadow/extension/implicit_gemm.h
@@ -105,11 +105,11 @@ template<int dim, typename LhsExp, typename RhsExp, typename DType>
 struct ShapeCheck<dim, ImplicitGEMMExp<LhsExp, RhsExp, DType> > {
   inline static Shape<dim>
   Check(const ImplicitGEMMExp<LhsExp, RhsExp, DType> &t) {
-    CHECK(dim == 2)
+    MSHADOW_CHECK(dim == 2)
         << "ImplicitGEMMExp only support 2 dimension";
     Shape<dim> shape1 = ShapeCheck<dim, LhsExp>::Check(t.lhs_);
     Shape<dim> shape2 = ShapeCheck<dim, RhsExp>::Check(t.rhs_);
-    CHECK_EQ(shape1[1], shape2[0])
+    MSHADOW_CHECK_EQ(shape1[1], shape2[0])
       << "implicit_dot The matrix shape do  not match";
     return t.shape_;
   }

--- a/mshadow/extension/one_hot.h
+++ b/mshadow/extension/one_hot.h
@@ -67,7 +67,7 @@ template<int dim, typename IndexExp, typename DType>
 struct ShapeCheck<dim, OneHotEncodeExp<IndexExp, DType> > {
   inline static Shape<dim>
   Check(const OneHotEncodeExp<IndexExp, DType> &t) {
-    CHECK(dim == 2)
+    MSHADOW_CHECK(dim == 2)
         << "OneHotEncodeExp only support 2 dimension output";
     Shape<1> shape = ShapeCheck<1, IndexExp>::Check(t.index_);
     Shape<dim> ret;

--- a/mshadow/extension/pack_col2patch.h
+++ b/mshadow/extension/pack_col2patch.h
@@ -40,9 +40,9 @@ struct PackColToPatchXExp:
     const index_t o_height = (imshape[dstdim - 2] - psize_y) / pstride_y + 1;
     const index_t o_width  = (imshape[dstdim - 1] - psize_x) / pstride_x + 1;
     Shape<2> sshape = ShapeCheck<2, SrcExp>::Check(src_);
-    CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
+    MSHADOW_CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
       << "PackColToPatchExp: src.size(1) mismatch";
-    CHECK_EQ(sshape[0], psize_y * psize_x * imshape[dstdim - 3])
+    MSHADOW_CHECK_EQ(sshape[0], psize_y * psize_x * imshape[dstdim - 3])
       << "PackColToPatchExp: src.size(0) mismatch";
   }
 };
@@ -66,7 +66,7 @@ pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
                index_t psize_x, index_t pstride) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
-  CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
+  MSHADOW_CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
     << "PackColToPatch:image shape smaller than patch size";
   return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
                                                    psize_y, psize_x, pstride, pstride);
@@ -81,7 +81,7 @@ pack_col2patch(const expr::Exp<SrcExp, DType, etype> &src,
                index_t psize_x, index_t pstride_y, index_t pstride_x) {
   TypeCheckPass<ExpInfo<SrcExp>::kDim == 2>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
-  CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
+  MSHADOW_CHECK(imshape[dstdim - 1] >= psize_x && imshape[dstdim - 2] >= psize_y)
     << "PackColToPatch:image shape smaller than patch size";
   return PackColToPatchXExp<SrcExp, DType, dstdim>(src.self(), imshape,
                                                    psize_y, psize_x, pstride_y, pstride_x);

--- a/mshadow/extension/reduce_with_axis.h
+++ b/mshadow/extension/reduce_with_axis.h
@@ -34,7 +34,7 @@ struct ReduceWithAxisExp:
   /*! constructor */
   explicit ReduceWithAxisExp(const SrcExp &src, int axis)
     : src_(src) {
-    CHECK(srcdim > axis) << "reduce axis out of bound";
+    MSHADOW_CHECK(srcdim > axis) << "reduce axis out of bound";
     Shape<srcdim> src_shape = ShapeCheck<srcdim, SrcExp>::Check(src_);
     this->leading_ = 1;
     for (index_t i = 0; i < axis; ++i) {

--- a/mshadow/extension/reshape.h
+++ b/mshadow/extension/reshape.h
@@ -29,7 +29,7 @@ struct ReshapeExp:
   ReshapeExp(const SrcExp &src, Shape<dimdst> shape)
       : src_(src) {
     Shape<dimsrc> ishape = ShapeCheck<dimsrc, SrcExp>::Check(src_);
-    CHECK_EQ(ishape.Size(), shape.Size()) << "reshape size must match";
+    MSHADOW_CHECK_EQ(ishape.Size(), shape.Size()) << "reshape size must match";
     ishapex_ = ishape[dimsrc - 1];
     this->shape_ = shape;
   }

--- a/mshadow/extension/slice.h
+++ b/mshadow/extension/slice.h
@@ -33,7 +33,7 @@ struct SliceExp : public TRValue<SliceExp<SrcExp,
       : src_(src), ch_begin_(begin) {
     shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
     ch_old_ = shape_[dimslice];
-    CHECK(begin < shape_[dimslice] && end <= shape_[dimslice])
+    MSHADOW_CHECK(begin < shape_[dimslice] && end <= shape_[dimslice])
         << "The slice went out of range";
     shape_[dimslice] = end - begin;
   }

--- a/mshadow/extension/spatial_pool.h
+++ b/mshadow/extension/spatial_pool.h
@@ -38,7 +38,7 @@ struct PoolingExp:
              index_t ksize_y, index_t ksize_x, index_t kstride)
       : src_(src), ksize_y_(ksize_y), ksize_x_(ksize_x), kstride_(kstride) {
     Shape<srcdim> sshape = ShapeCheck<srcdim, SrcExp>::Check(src_);
-    CHECK(sshape[srcdim - 1] >= ksize_x && sshape[srcdim - 2] >= ksize_y)
+    MSHADOW_CHECK(sshape[srcdim - 1] >= ksize_x && sshape[srcdim - 2] >= ksize_y)
       << "PoolingExp: kernel must be smaller than image";
     this->src_height_ = sshape[srcdim - 2];
     this->src_width_  = sshape[srcdim - 1];
@@ -51,7 +51,7 @@ struct PoolingExp:
              index_t ksize_y, index_t ksize_x, index_t kstride)
       : src_(src), ksize_y_(ksize_y), ksize_x_(ksize_x), kstride_(kstride) {
     Shape<srcdim> sshape = ShapeCheck<srcdim, SrcExp>::Check(src_);
-    CHECK(sshape[srcdim - 1] >= ksize_x && sshape[srcdim - 2] >= ksize_y)
+    MSHADOW_CHECK(sshape[srcdim - 1] >= ksize_x && sshape[srcdim - 2] >= ksize_y)
       << "PoolingExp: kernel must be smaller than image";
     this->src_height_ = sshape[srcdim - 2];
     this->src_width_  = sshape[srcdim - 1];

--- a/mshadow/extension/spatial_unpool.h
+++ b/mshadow/extension/spatial_unpool.h
@@ -47,11 +47,11 @@ struct UnPoolingExp:
         ksize_y_(ksize_y), ksize_x_(ksize_x), kstride_(kstride) {
     Shape<srcdim> pshape = ShapeCheck<srcdim, SrcExp>::Check(grad_pooled);
     typedef ShapeCheck<srcdim, SrcExp> ShapeCheckSrcDimSrcExp;
-    CHECK_EQ(pshape, ShapeCheckSrcDimSrcExp::Check(data_pooled))
+    MSHADOW_CHECK_EQ(pshape, ShapeCheckSrcDimSrcExp::Check(data_pooled))
       << "UnPoolingExp: pooled shape mismatch";
     Shape<srcdim> sshape = ShapeCheck<srcdim, SrcExp>::Check(data_src);
     for (int k = 0;  k < srcdim - 2; ++k) {
-      CHECK_EQ(pshape[k], sshape[k]) << "UnPoolingExp: pool and src shape mismatch";
+      MSHADOW_CHECK_EQ(pshape[k], sshape[k]) << "UnPoolingExp: pool and src shape mismatch";
     }
     pshape_x_ = pshape[srcdim - 1];
     pshape_y_ = pshape[srcdim - 2];

--- a/mshadow/extension/take.h
+++ b/mshadow/extension/take.h
@@ -75,7 +75,7 @@ template<int dim, typename IndexExp, typename SrcExp, typename DType>
 struct ShapeCheck<dim, TakeExp<IndexExp, SrcExp, DType> > {
   inline static Shape<dim>
   Check(const TakeExp<IndexExp, SrcExp, DType> &t) {
-    CHECK(dim == 2)
+    MSHADOW_CHECK(dim == 2)
       << "TakeExp only support 2D output";
     Shape<1> dshape = ShapeCheck<1, IndexExp>::Check(t.index_);
     Shape<2> wshape = ShapeCheck<2, SrcExp>::Check(t.src_);

--- a/mshadow/extension/take_grad.h
+++ b/mshadow/extension/take_grad.h
@@ -88,7 +88,7 @@ template<int dim, typename IndexExp, typename SrcExp, typename DType>
 struct ShapeCheck<dim, TakeGradExp<IndexExp, SrcExp, DType> > {
   inline static Shape<dim>
   Check(const TakeGradExp<IndexExp, SrcExp, DType> &t) {
-    CHECK(dim == 2)
+    MSHADOW_CHECK(dim == 2)
       << "TakeGradExp only support 2D output";
     // Shape<1> dshape = ShapeCheck<1, IndexExp>::Check(t.index_);
     Shape<2> gshape = ShapeCheck<2, SrcExp>::Check(t.src_);

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -45,7 +45,7 @@ struct UnpackPatchToColXExp:
       : img_(img), psize_y_(psize_y), psize_x_(psize_x),
       pstride_y_(pstride_y), pstride_x_(pstride_x) {
     Shape<srcdim> imshape = ShapeCheck<srcdim, SrcExp>::Check(img_);
-    CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)
+    MSHADOW_CHECK(imshape[srcdim - 1] >= psize_x && imshape[srcdim - 2] >= psize_y)
       << "UnpackPatchToCol:image shape smaller than patch size";
     this->i_channel_ = imshape[srcdim - 3];
     this->i_height_  = imshape[srcdim - 2];

--- a/mshadow/io.h
+++ b/mshadow/io.h
@@ -107,16 +107,16 @@ template<int dim, typename DType, typename TStream>
 inline void LoadBinary(TStream &fi, // NOLINT(*)
                        Tensor<cpu, dim, DType> *dst_, bool pre_alloc) {
   Shape<dim> shape;
-  CHECK_NE(fi.Read(&shape, sizeof(shape)), 0) << "mshadow::LoadBinary";
+  MSHADOW_CHECK_NE(fi.Read(&shape, sizeof(shape)), 0) << "mshadow::LoadBinary";
   if (pre_alloc) {
-    CHECK_EQ(shape, dst_->shape_) << "LoadBinary, shape do not match pre-allocated shape";
+    MSHADOW_CHECK_EQ(shape, dst_->shape_) << "LoadBinary, shape do not match pre-allocated shape";
   } else {
     dst_->shape_ = shape; AllocSpace(dst_);
   }
   Tensor<cpu, 2, DType> dst = dst_->FlatTo2D();
   if (dst.size(0) == 0) return;
   for (index_t i = 0; i < dst.size(0); ++i) {
-    CHECK_NE(fi.Read(dst[i].dptr_, sizeof(DType) * dst.size(1)), 0) << "mshadow::LoadBinary";
+    MSHADOW_CHECK_NE(fi.Read(dst[i].dptr_, sizeof(DType) * dst.size(1)), 0) << "mshadow::LoadBinary";
   }
 }
 template<int dim, typename DType, typename TStream>
@@ -125,7 +125,7 @@ inline void LoadBinary(TStream &fi, // NOLINT(*)
   Tensor<cpu, dim, DType> tmp;
   LoadBinary(fi, &tmp, false);
   if (pre_alloc) {
-    CHECK_EQ(tmp.shape, dst->shape_) << "LoadBinary, shape do not match pre-allocated shape";
+    MSHADOW_CHECK_EQ(tmp.shape, dst->shape_) << "LoadBinary, shape do not match pre-allocated shape";
   } else {
     dst->shape = tmp.shape; AllocSpace(dst);
   }

--- a/mshadow/io.h
+++ b/mshadow/io.h
@@ -116,7 +116,8 @@ inline void LoadBinary(TStream &fi, // NOLINT(*)
   Tensor<cpu, 2, DType> dst = dst_->FlatTo2D();
   if (dst.size(0) == 0) return;
   for (index_t i = 0; i < dst.size(0); ++i) {
-    MSHADOW_CHECK_NE(fi.Read(dst[i].dptr_, sizeof(DType) * dst.size(1)), 0) << "mshadow::LoadBinary";
+    MSHADOW_CHECK_NE(fi.Read(dst[i].dptr_, sizeof(DType) * dst.size(1)), 0)
+      << "mshadow::LoadBinary";
   }
 }
 template<int dim, typename DType, typename TStream>
@@ -125,7 +126,8 @@ inline void LoadBinary(TStream &fi, // NOLINT(*)
   Tensor<cpu, dim, DType> tmp;
   LoadBinary(fi, &tmp, false);
   if (pre_alloc) {
-    MSHADOW_CHECK_EQ(tmp.shape, dst->shape_) << "LoadBinary, shape do not match pre-allocated shape";
+    MSHADOW_CHECK_EQ(tmp.shape, dst->shape_)
+      << "LoadBinary, shape do not match pre-allocated shape";
   } else {
     dst->shape = tmp.shape; AllocSpace(dst);
   }

--- a/mshadow/logging.h
+++ b/mshadow/logging.h
@@ -70,73 +70,73 @@ inline void InitLogging(const char* argv0) {
 }
 
 // Always-on checking
-#define CHECK(x)                                           \
+#define MSHADOW_CHECK(x)                                           \
   if (!(x))                                                \
     dmlc::LogMessageFatal(__FILE__, __LINE__).stream() << "Check "  \
       "failed: " #x << ' '
-#define CHECK_LT(x, y) CHECK((x) < (y))
-#define CHECK_GT(x, y) CHECK((x) > (y))
-#define CHECK_LE(x, y) CHECK((x) <= (y))
-#define CHECK_GE(x, y) CHECK((x) >= (y))
-#define CHECK_EQ(x, y) CHECK((x) == (y))
-#define CHECK_NE(x, y) CHECK((x) != (y))
-#define CHECK_NOTNULL(x) \
+#define MSHADOW_CHECK_LT(x, y) MSHADOW_CHECK((x) < (y))
+#define MSHADOW_CHECK_GT(x, y) MSHADOW_CHECK((x) > (y))
+#define MSHADOW_CHECK_LE(x, y) MSHADOW_CHECK((x) <= (y))
+#define MSHADOW_CHECK_GE(x, y) MSHADOW_CHECK((x) >= (y))
+#define MSHADOW_CHECK_EQ(x, y) MSHADOW_CHECK((x) == (y))
+#define MSHADOW_CHECK_NE(x, y) MSHADOW_CHECK((x) != (y))
+#define MSHADOW_CHECK_NOTNULL(x) \
   ((x) == NULL ? dmlc::LogMessageFatal(__FILE__, __LINE__).stream() << "Check  notnull: "  #x << ' ', (x) : (x)) // NOLINT(*)
 // Debug-only checking.
 #ifdef NDEBUG
-#define DCHECK(x) \
-  while (false) CHECK(x)
-#define DCHECK_LT(x, y) \
-  while (false) CHECK((x) < (y))
-#define DCHECK_GT(x, y) \
-  while (false) CHECK((x) > (y))
-#define DCHECK_LE(x, y) \
-  while (false) CHECK((x) <= (y))
-#define DCHECK_GE(x, y) \
-  while (false) CHECK((x) >= (y))
-#define DCHECK_EQ(x, y) \
-  while (false) CHECK((x) == (y))
-#define DCHECK_NE(x, y) \
-  while (false) CHECK((x) != (y))
+#define MSHADOW_DCHECK(x) \
+  while (false) MSHADOW_CHECK(x)
+#define MSHADOW_DCHECK_LT(x, y) \
+  while (false) MSHADOW_CHECK((x) < (y))
+#define MSHADOW_DCHECK_GT(x, y) \
+  while (false) MSHADOW_CHECK((x) > (y))
+#define MSHADOW_DCHECK_LE(x, y) \
+  while (false) MSHADOW_CHECK((x) <= (y))
+#define MSHADOW_DCHECK_GE(x, y) \
+  while (false) MSHADOW_CHECK((x) >= (y))
+#define MSHADOW_DCHECK_EQ(x, y) \
+  while (false) MSHADOW_CHECK((x) == (y))
+#define MSHADOW_DCHECK_NE(x, y) \
+  while (false) MSHADOW_CHECK((x) != (y))
 #else
-#define DCHECK(x) CHECK(x)
-#define DCHECK_LT(x, y) CHECK((x) < (y))
-#define DCHECK_GT(x, y) CHECK((x) > (y))
-#define DCHECK_LE(x, y) CHECK((x) <= (y))
-#define DCHECK_GE(x, y) CHECK((x) >= (y))
-#define DCHECK_EQ(x, y) CHECK((x) == (y))
-#define DCHECK_NE(x, y) CHECK((x) != (y))
+#define MSHADOW_DCHECK(x) MSHADOW_CHECK(x)
+#define MSHADOW_DCHECK_LT(x, y) MSHADOW_CHECK((x) < (y))
+#define MSHADOW_DCHECK_GT(x, y) MSHADOW_CHECK((x) > (y))
+#define MSHADOW_DCHECK_LE(x, y) MSHADOW_CHECK((x) <= (y))
+#define MSHADOW_DCHECK_GE(x, y) MSHADOW_CHECK((x) >= (y))
+#define MSHADOW_DCHECK_EQ(x, y) MSHADOW_CHECK((x) == (y))
+#define MSHADOW_DCHECK_NE(x, y) MSHADOW_CHECK((x) != (y))
 #endif  // NDEBUG
 
-#define LOG_INFO dmlc::LogMessage(__FILE__, __LINE__)
-#define LOG_ERROR LOG_INFO
-#define LOG_WARNING LOG_INFO
-#define LOG_FATAL dmlc::LogMessageFatal(__FILE__, __LINE__)
-#define LOG_QFATAL LOG_FATAL
+#define MSHADOW_LOG_INFO dmlc::LogMessage(__FILE__, __LINE__)
+#define MSHADOW_LOG_ERROR MSHADOW_LOG_INFO
+#define MSHADOW_LOG_WARNING MSHADOW_LOG_INFO
+#define MSHADOW_LOG_FATAL dmlc::LogMessageFatal(__FILE__, __LINE__)
+#define MSHADOW_LOG_QFATAL MSHADOW_LOG_FATAL
 
 // Poor man version of VLOG
-#define VLOG(x) LOG_INFO.stream()
+#define MSHADOW_VLOG(x) MSHADOW_LOG_INFO.stream()
 
-#define LOG(severity) LOG_##severity.stream()
-#define LG LOG_INFO.stream()
-#define LOG_IF(severity, condition) \
-  !(condition) ? (void)0 : dmlc::LogMessageVoidify() & LOG(severity)
+#define MSHADOW_LOG(severity) MSHADOW_LOG_##severity.stream()
+#define MSHADOW_LG MSHADOW_LOG_INFO.stream()
+#define MSHADOW_LOG_IF(severity, condition) \
+  !(condition) ? (void)0 : dmlc::LogMessageVoidify() & MSHADOW_LOG(severity)
 
 #ifdef NDEBUG
-#define LOG_DFATAL LOG_ERROR
-#define DFATAL ERROR
-#define DLOG(severity) true ? (void)0 : dmlc::LogMessageVoidify() & LOG(severity)
-#define DLOG_IF(severity, condition) \
-  (true || !(condition)) ? (void)0 : dmlc::LogMessageVoidify() & LOG(severity)
+#define MSHADOW_LOG_DFATAL MSHADOW_LOG_ERROR
+#define MSHADOW_DFATAL ERROR
+#define MSHADOW_DLOG(severity) true ? (void)0 : dmlc::LogMessageVoidify() & MSHADOW_LOG(severity)
+#define MSHADOW_DLOG_IF(severity, condition) \
+  (true || !(condition)) ? (void)0 : dmlc::LogMessageVoidify() & MSHADOW_LOG(severity)
 #else
-#define LOG_DFATAL LOG_FATAL
-#define DFATAL FATAL
-#define DLOG(severity) LOG(severity)
-#define DLOG_IF(severity, condition) LOG_IF(severity, condition)
+#define MSHADOW_LOG_DFATAL MSHADOW_LOG_FATAL
+#define MSHADOW_DFATAL FATAL
+#define MSHADOW_DLOG(severity) MSHADOW_LOG(severity)
+#define MSHADOW_DLOG_IF(severity, condition) MSHADOW_LOG_IF(severity, condition)
 #endif
 
 // Poor man version of LOG_EVERY_N
-#define LOG_EVERY_N(severity, n) LOG(severity)
+#define MSHADOW_LOG_EVERY_N(severity, n) MSHADOW_LOG(severity)
 
 class DateLogger {
  public:

--- a/mshadow/packet-inl.h
+++ b/mshadow/packet-inl.h
@@ -69,10 +69,10 @@ inline void* AlignedMallocPitch(size_t *out_pitch,
 #else
   void *res;
   int ret = posix_memalign(&res, 1 << bits, pitch * num_line);
-  CHECK_EQ(ret, 0) << "AlignedMallocPitch failed";
+  MSHADOW_CHECK_EQ(ret, 0) << "AlignedMallocPitch failed";
 #endif
   if (res == NULL) {
-    LOG(FATAL) << "AlignedMallocPitch failed";
+    MSHADOW_LOG(FATAL) << "AlignedMallocPitch failed";
   }
   return res;
 }

--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -233,14 +233,14 @@ class Random<gpu, DType> {
   explicit Random(int seed) {
     curandStatus_t status;
     status = curandCreateGenerator(&gen_, CURAND_RNG_PSEUDO_DEFAULT);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Can not create CURAND Generator";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Can not create CURAND Generator";
     this->Seed(seed);
     buffer_.Resize(Shape1(kRandBufferSize));
   }
   ~Random(void) DMLC_THROW_EXCEPTION {
     curandStatus_t status;
     status = curandDestroyGenerator(gen_);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Destory CURAND Gen failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Destory CURAND Gen failed";
   }
   /*!
    * \brief set the stream of computation
@@ -250,7 +250,7 @@ class Random<gpu, DType> {
     curandStatus_t status;
     status = curandSetStream(gen_, Stream<gpu>::GetStream(stream));
 
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "set_stream CURAND failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "set_stream CURAND failed";
   }
   /*!
    * \brief seed random number generator using this seed
@@ -259,7 +259,7 @@ class Random<gpu, DType> {
   inline void Seed(int seed) {
     curandStatus_t status;
     status = curandSetPseudoRandomGeneratorSeed(gen_, seed);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
   }
   /*!
    * \brief generate data from uniform [a,b)
@@ -317,22 +317,22 @@ class Random<gpu, DType> {
   inline void GenGaussian(float *dptr, size_t size, float mu, float sigma) {
     curandStatus_t status;
     status = curandGenerateNormal(gen_, dptr, size, mu, sigma);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
   }
   inline void GenGaussian(double *dptr, size_t size, double mu, double sigma) {
     curandStatus_t status;
     status = curandGenerateNormalDouble(gen_, dptr, size, mu, sigma);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
   }
   inline void GenUniform(float *dptr, size_t size) {
     curandStatus_t status;
     status = curandGenerateUniform(gen_, dptr, size);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
   }
   inline void GenUniform(double *dptr, size_t size) {
     curandStatus_t status;
     status = curandGenerateUniformDouble(gen_, dptr, size);
-    CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
   }
   /*! \brief random numbeer generator */
   curandGenerator_t gen_;

--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -317,12 +317,12 @@ class Random<gpu, DType> {
   inline void GenGaussian(float *dptr, size_t size, float mu, float sigma) {
     curandStatus_t status;
     status = curandGenerateNormal(gen_, dptr, size, mu, sigma);
-    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Gaussian failed: " << status;
   }
   inline void GenGaussian(double *dptr, size_t size, double mu, double sigma) {
     curandStatus_t status;
     status = curandGenerateNormalDouble(gen_, dptr, size, mu, sigma);
-    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Uniform failed";
+    MSHADOW_CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "CURAND Gen Gaussian failed";
   }
   inline void GenUniform(float *dptr, size_t size) {
     curandStatus_t status;

--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -52,7 +52,7 @@ struct Stream<gpu> {
     cudaError_t err = cudaStreamQuery(stream_);
     if (err == cudaSuccess) return true;
     if (err == cudaErrorNotReady) return false;
-    LOG(FATAL) << cudaGetErrorString(err);
+    MSHADOW_LOG(FATAL) << cudaGetErrorString(err);
     return false;
   }
   /*!
@@ -62,7 +62,7 @@ struct Stream<gpu> {
   inline static cudaStream_t GetStream(Stream<gpu> *stream) {
     if (stream == NULL) {
 #if MSHADOW_FORCE_STREAM
-      LOG(FATAL) << "Default GPU stream was used when MSHADOW_FORCE_STREAM was on";
+      MSHADOW_LOG(FATAL) << "Default GPU stream was used when MSHADOW_FORCE_STREAM was on";
 #endif
       return 0;
     } else {
@@ -87,7 +87,7 @@ struct Stream<gpu> {
     if (blas_handle_ownership_ == OwnHandle) {
       cublasStatus_t err = cublasDestroy(blas_handle_);
       blas_handle_ownership_ = NoHandle;
-      CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Destory cublas handle failed";
+      MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Destory cublas handle failed";
     }
   }
   /*! \brief Destory original blas handle and create a new one */
@@ -95,7 +95,7 @@ struct Stream<gpu> {
     this->DestoryBlasHandle();
     cublasStatus_t err = cublasCreate(&blas_handle_);
     blas_handle_ownership_ = OwnHandle;
-    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Create cublas handle failed";
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Create cublas handle failed";
   }
 // #if MSHADOW_USE_CUDNN && defined(__CUDACC__)
 #if MSHADOW_USE_CUDNN == 1
@@ -103,7 +103,7 @@ struct Stream<gpu> {
     if (stream == NULL) {
       return 0;
     } else {
-      CHECK_NE(stream->dnn_handle_ownership_, NoHandle) << "No handle exist in source stream";
+      MSHADOW_CHECK_NE(stream->dnn_handle_ownership_, NoHandle) << "No handle exist in source stream";
       return stream->dnn_handle_;
     }
   }
@@ -113,7 +113,7 @@ struct Stream<gpu> {
 #if MSHADOW_USE_CUDNN == 1
     if (dnn_handle_ownership_ == OwnHandle) {
       cudnnStatus_t err = cudnnDestroy(dnn_handle_);
-      CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
+      MSHADOW_CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
     }
 #endif
   }
@@ -122,9 +122,9 @@ struct Stream<gpu> {
 #if MSHADOW_USE_CUDNN == 1
     this->DestroyDnnHandle();
     cudnnStatus_t err = cudnnCreate(&dnn_handle_);
-    CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
+    MSHADOW_CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
     err = cudnnSetStream(dnn_handle_, stream_);
-    CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
+    MSHADOW_CHECK_EQ(err, CUDNN_STATUS_SUCCESS) << cudnnGetErrorString(err);
     this->dnn_handle_ownership_ = OwnHandle;
 #endif
   }

--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -105,7 +105,8 @@ struct Stream<gpu> {
     if (stream == NULL) {
       return 0;
     } else {
-      MSHADOW_CHECK_NE(stream->dnn_handle_ownership_, NoHandle) << "No handle exist in source stream";
+      MSHADOW_CHECK_NE(stream->dnn_handle_ownership_, NoHandle)
+        << "No handle exist in source stream";
       return stream->dnn_handle_;
     }
   }

--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -94,8 +94,10 @@ struct Stream<gpu> {
   inline void CreateBlasHandle() {
     this->DestoryBlasHandle();
     cublasStatus_t err = cublasCreate(&blas_handle_);
-    blas_handle_ownership_ = OwnHandle;
     MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Create cublas handle failed";
+    err = cublasSetStream(blas_handle_, stream_);
+    MSHADOW_CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Set cublas handle failed";
+    this->blas_handle_ownership_ = OwnHandle;
   }
 // #if MSHADOW_USE_CUDNN && defined(__CUDACC__)
 #if MSHADOW_USE_CUDNN == 1

--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -77,7 +77,7 @@ struct Stream<gpu> {
     if (stream == NULL) {
       return 0;
     } else {
-      CHECK_NE(stream->blas_handle_ownership_, NoHandle)
+      MSHADOW_CHECK_NE(stream->blas_handle_ownership_, NoHandle)
         << "No handle exist in source stream";
       return stream->blas_handle_;
     }

--- a/mshadow/tensor_blob.h
+++ b/mshadow/tensor_blob.h
@@ -43,6 +43,17 @@ struct TShape {
     }
   }
   /*!
+   * \brief move constructor from Shape
+   * \param s the source shape
+   */
+  template<int dim>
+  TShape(const Shape<dim> &s)  // NOLINT(*)
+      : ndim_(0),
+        num_heap_allocated_(0),
+        data_heap_(NULL) {
+    this->CopyFrom(s.shape_, s.shape_ + dim);
+  }
+  /*!
    * \brief construct the TShape from content of iterator
    * \param begin the beginning of iterator
    * \param end end the end of the iterator

--- a/mshadow/tensor_blob.h
+++ b/mshadow/tensor_blob.h
@@ -195,7 +195,8 @@ struct TShape {
    */
   template<int dim>
   inline Shape<dim> get(void) const {
-    MSHADOW_CHECK_EQ(dim, ndim_) << "dimension do not match target dimension " << dim << " vs " << ndim_;
+    MSHADOW_CHECK_EQ(dim, ndim_)
+      << "dimension do not match target dimension " << dim << " vs " << ndim_;
     const index_t *d = this->data();
     Shape<dim> s;
     for (int i = 0; i < dim; ++i) {
@@ -406,7 +407,7 @@ inline std::istream &operator>>(std::istream &is, TShape &shape) {
     }                                               \
     break;                                          \
   default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type;     \
+    MSHADOW_LOG(FATAL) << "Unknown type enum " << type;     \
   }
 
 #define MSHADOW_REAL_TYPE_SWITCH(type, DType, ...)  \
@@ -430,15 +431,15 @@ inline std::istream &operator>>(std::istream &is, TShape &shape) {
     }                                               \
     break;                                          \
   case mshadow::kUint8:                             \
-    LOG(FATAL) << "This operation only support "    \
+    MSHADOW_LOG(FATAL) << "This operation only support "    \
                   "floating point types not uint8"; \
     break;                                          \
   case mshadow::kInt32:                             \
-    LOG(FATAL) << "This operation only support "      \
+    MSHADOW_LOG(FATAL) << "This operation only support "      \
                   "floating point types, not int32";  \
     break;                                            \
   default:                                            \
-    LOG(FATAL) << "Unknown type enum " << type;       \
+    MSHADOW_LOG(FATAL) << "Unknown type enum " << type;       \
   }
 
 /*! \brief get data type size from type enum */
@@ -553,7 +554,7 @@ class TBlob {
   inline Tensor<Device, 2, DType> FlatTo2D(Stream<Device> *stream = NULL) const {
     MSHADOW_CHECK(Device::kDevMask == dev_mask_)
       << "TBlob.get: device type do not match specified type";
-    CHECK(DataType<DType>::kFlag == type_flag_)
+    MSHADOW_CHECK(DataType<DType>::kFlag == type_flag_)
       << "TBlob.get_with_shape: data type do not match specified type."
       << "Expected: " << type_flag_ << " v.s. given " << DataType<DType>::kFlag;
     return Tensor<Device, 2, DType>(static_cast<DType*>(dptr_),

--- a/mshadow/tensor_blob.h
+++ b/mshadow/tensor_blob.h
@@ -195,7 +195,7 @@ struct TShape {
    */
   template<int dim>
   inline Shape<dim> get(void) const {
-    CHECK_EQ(dim, ndim_) << "dimension do not match target dimension " << dim << " vs " << ndim_;
+    MSHADOW_CHECK_EQ(dim, ndim_) << "dimension do not match target dimension " << dim << " vs " << ndim_;
     const index_t *d = this->data();
     Shape<dim> s;
     for (int i = 0; i < dim; ++i) {
@@ -473,7 +473,7 @@ class TBlob {
    */
   template<typename Device, typename DType>
   inline Tensor<Device, 2, DType> FlatTo2D(Stream<Device> *stream = NULL) const {
-    CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
+    MSHADOW_CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
       << "TBlob.get: device type do not match specified type";
     return Tensor<Device, 2, DType>(static_cast<DType*>(dptr_),
                                     shape_.FlatTo2D(), stride_, stream);
@@ -505,7 +505,7 @@ class TBlob {
    */
   template<typename Device, int dim, typename DType>
   inline Tensor<Device, dim, DType> get(Stream<Device> *stream = NULL) const {
-    CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
+    MSHADOW_CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
       << "TBlob.get: device type do not match specified type";
     return Tensor<Device, dim, DType>(static_cast<DType*>(dptr_),
                                        shape_.get<dim>(),
@@ -524,10 +524,10 @@ class TBlob {
   template<typename Device, int dim, typename DType>
   inline Tensor<Device, dim, DType> get_with_shape(const Shape<dim> &shape,
                                                    Stream<Device> *stream = NULL) const {
-    CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
+    MSHADOW_CHECK(Device::kDevMask == dev_mask_ && DataType<DType>::kFlag == type_flag_)
       << "TBlob.get_with_shape: device type do not match specified type";
-    CHECK_EQ(this->CheckContiguous(), true) << "TBlob.get_reshape: must be contiguous";
-    CHECK_EQ(this->shape_.Size(), shape.Size())
+    MSHADOW_CHECK_EQ(this->CheckContiguous(), true) << "TBlob.get_reshape: must be contiguous";
+    MSHADOW_CHECK_EQ(this->shape_.Size(), shape.Size())
       << "TBlob.get_with_shape: new and old shape do not match total elements";
     return Tensor<Device, dim, DType>(static_cast<DType*>(dptr_),
                                       shape,

--- a/mshadow/tensor_container.h
+++ b/mshadow/tensor_container.h
@@ -177,7 +177,7 @@ class TensorContainer: public Tensor<Device, dimension, DType> {
       this->data_.shape_[0] = 0;
       try {
         mshadow::FreeSpace(&data_);
-      } catch (const dmlc::Error &e) {
+      } catch (const mshadow::Error &e) {
         this->dptr_ = data_.dptr_ = NULL;
         throw e;
       }

--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -75,14 +75,14 @@ inline void FreeHost_<cpu>(void *dptr) {
 template<typename xpu, int dim, typename DType>
 inline void AllocHost(Tensor<cpu, dim, DType> *obj) {
   obj->stride_ = obj->size(dim - 1);
-  CHECK_EQ(obj->CheckContiguous(), true) << "AllocHost";
+  MSHADOW_CHECK_EQ(obj->CheckContiguous(), true) << "AllocHost";
   void *dptr = AllocHost_<xpu>(obj->MSize() * sizeof(DType));
   obj->dptr_ = reinterpret_cast<DType*>(dptr);
 }
 template<typename xpu, int dim, typename DType>
 inline void FreeHost(Tensor<cpu, dim, DType> *obj) {
   if (obj->dptr_ == NULL) {
-    LOG(FATAL) << "FreeHost:: double free";
+    MSHADOW_LOG(FATAL) << "FreeHost:: double free";
   }
   FreeHost_<xpu>(obj->dptr_);
   obj->dptr_ = NULL;
@@ -121,7 +121,7 @@ template<int dim, typename DType>
 inline void Copy(Tensor<cpu, dim, DType> _dst,
                  const Tensor<cpu, dim, DType> &_src,
                  Stream<cpu> *stream) {
-  CHECK_EQ(_dst.shape_, _src.shape_)
+  MSHADOW_CHECK_EQ(_dst.shape_, _src.shape_)
       << "Copy:shape mismatch:" << _dst.shape_ << " vs " << _src.shape_;
   if (_dst.CheckContiguous() && _src.CheckContiguous()) {
     memcpy(_dst.dptr_, _src.dptr_, sizeof(DType) * _dst.shape_.Size());
@@ -182,7 +182,7 @@ inline void MapExp(TRValue<R, cpu, dim, DType> *dst,
       ::Error_All_Tensor_in_Exp_Must_Have_Same_Type();
   Shape<dim> eshape = expr::ShapeCheck<dim, E>::Check(exp.self());
   Shape<dim> dshape = expr::ShapeCheck<dim, R>::Check(dst->self());
-  CHECK(eshape[0] == 0 || eshape == dshape)
+  MSHADOW_CHECK(eshape[0] == 0 || eshape == dshape)
       << "Assignment: Shape of Tensors are not consistent with target";
   MapExpCPUEngine<expr::PacketCheck<E, MSHADOW_DEFAULT_PACKET>::kPass,
                   Saver, R, dim, DType, E, etype>
@@ -199,8 +199,8 @@ inline void MapReduceKeepLowest(TRValue<R, cpu, 1, DType> *dst,
   Shape<2> eshape = expr::ShapeCheck<expr::ExpInfo<E>::kDim, E>
       ::Check(exp.self()).FlatTo2D();
   Shape<1> dshape = expr::ShapeCheck<1, R>::Check(dst->self());
-  CHECK_EQ(eshape[1], dshape[0]) << "MapReduceKeepLowest::reduction dimension do not match";
-  CHECK_NE(eshape[0], 0) << "can not reduce over empty tensor";
+  MSHADOW_CHECK_EQ(eshape[1], dshape[0]) << "MapReduceKeepLowest::reduction dimension do not match";
+  MSHADOW_CHECK_NE(eshape[0], 0) << "can not reduce over empty tensor";
   // execution
   expr::Plan<R, DType> dplan = MakePlan(dst->self());
   expr::Plan<E, DType> splan = MakePlan(exp.self());
@@ -224,7 +224,7 @@ inline void MapReduceKeepHighDim(TRValue<R, cpu, 1, DType> *dst,
   EShape eshape = expr::ShapeCheck<expr::ExpInfo<E>::kDim, E>
       ::Check(exp.self());
   Shape<1> dshape = expr::ShapeCheck<1, R>::Check(dst->self());
-  CHECK_EQ(eshape[dimkeep], dshape[0])
+  MSHADOW_CHECK_EQ(eshape[dimkeep], dshape[0])
     << "MapReduceKeepHighDim::reduction dimension do not match";
   // use equvalent form
   Shape<4> pshape = Shape4(eshape.ProdShape(0, dimkeep),
@@ -304,7 +304,7 @@ inline void SoftmaxGrad(Tensor<cpu, 3, DType> dst,
 template<typename DType>
 inline void Softmax(Tensor<cpu, 2, DType> dst,
                     const Tensor<cpu, 2, DType> &energy) {
-  CHECK_EQ(dst.shape_, energy.shape_) << "Softmax: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, energy.shape_) << "Softmax: shape mismatch";
   for (index_t y = 0; y < dst.size(0); ++y) {
     Softmax(dst[y], energy[y]);
   }
@@ -313,7 +313,7 @@ inline void Softmax(Tensor<cpu, 2, DType> dst,
 template<typename DType>
 inline void Softmax(Tensor<cpu, 3, DType> dst,
                     const Tensor<cpu, 3, DType> &energy) {
-  CHECK_EQ(dst.shape_, energy.shape_) << "Softmax: shape mismatch";
+  MSHADOW_CHECK_EQ(dst.shape_, energy.shape_) << "Softmax: shape mismatch";
   for (index_t y = 0; y < dst.size(0); ++y) {
     for (index_t n = 0; n < dst.size(2); ++n) {
       DType mmax = energy[y][0][n];
@@ -337,9 +337,9 @@ template<typename Device, typename DType>
 inline void VectorDot(Tensor<Device, 1, DType> dst,
                       const Tensor<Device, 1, DType> &lhs,
                       const Tensor<Device, 1, DType> &rhs) {
-  CHECK_EQ(lhs.size(0), rhs.size(0))
+  MSHADOW_CHECK_EQ(lhs.size(0), rhs.size(0))
       << "VectorDot: Shape mismatch";
-  CHECK_EQ(dst.size(0), 1)
+  MSHADOW_CHECK_EQ(dst.size(0), 1)
       << "VectorDot: expect dst to be scalar";
   expr::BLASEngine<Device>::SetStream(lhs.stream_);
   mshadow::expr::BLASEngine<Device>::dot(

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -17,13 +17,13 @@ inline void InitTensorEngine<gpu>(int dev_id) {
   int device_id = 0;
   int device_count = 0;
   cudaGetDeviceCount(&device_count);
-  CHECK_GT(device_count, 0) << "Cannot find CUDA device. Please check CUDA-Configuration";
+  MSHADOW_CHECK_GT(device_count, 0) << "Cannot find CUDA device. Please check CUDA-Configuration";
   if (dev_id < 0) {
     device_id = 0;
   } else {
     device_id = dev_id;
   }
-  CHECK_LT(device_id, device_count) << "Incorrect Device ID";
+  MSHADOW_CHECK_LT(device_id, device_count) << "Incorrect Device ID";
   MSHADOW_CUDA_CALL(cudaSetDevice(device_id));
   MSHADOW_CUDA_CALL(cudaGetDeviceProperties(&prop, device_id));
 }
@@ -59,7 +59,7 @@ inline void Copy(Tensor<A, dim, DType> _dst,
                  Tensor<B, dim, DType> _src,
                  cudaMemcpyKind kind,
                  Stream<gpu> *stream) {
-  CHECK_EQ(_dst.shape_, _src.shape_) << "Copy:shape mismatch";
+  MSHADOW_CHECK_EQ(_dst.shape_, _src.shape_) << "Copy:shape mismatch";
   Tensor<A, 2, DType> dst = _dst.FlatTo2D();
   Tensor<B, 2, DType> src = _src.FlatTo2D();
   MSHADOW_CUDA_CALL(cudaMemcpy2DAsync(dst.dptr_, dst.stride_ * sizeof(DType),
@@ -106,7 +106,7 @@ inline void MapExp(TRValue<R, gpu, dim, DType> *dst,
       ::Error_All_Tensor_in_Exp_Must_Have_Same_Type();
   Shape<dim> eshape = expr::ShapeCheck<dim, E>::Check(exp.self());
   Shape<dim> dshape = expr::ShapeCheck<dim, R>::Check(dst->self());
-  CHECK(eshape[0] == 0 || eshape == dshape)
+  MSHADOW_CHECK(eshape[0] == 0 || eshape == dshape)
     << "Assignment: Shape of Tensors are not consistent with target";
   cuda::MapPlan<Saver>(MakePlan(dst->self()),
                        MakePlan(exp.self()),
@@ -124,8 +124,8 @@ inline void MapReduceKeepLowest(TRValue<R, gpu, 1, DType> *dst,
   Shape<2> eshape = expr::ShapeCheck<expr::ExpInfo<E>::kDim, E>
       ::Check(exp.self()).FlatTo2D();
   Shape<1> dshape = expr::ShapeCheck<1, R>::Check(dst->self());
-  CHECK_EQ(eshape[1], dshape[0]) << "MapReduceKeepLowest::reduction dimension do not match";
-  CHECK_NE(eshape[0], 0) << "can not reduce over empty tensor";
+  MSHADOW_CHECK_EQ(eshape[1], dshape[0]) << "MapReduceKeepLowest::reduction dimension do not match";
+  MSHADOW_CHECK_NE(eshape[0], 0) << "can not reduce over empty tensor";
   cuda::MapReduceKeepLowest<Saver, Reducer>
       (MakePlan(dst->self()), MakePlan(exp.self()), scale, eshape,
        Stream<gpu>::GetStream(expr::StreamInfo<gpu, R>::Get(dst->self())));
@@ -142,7 +142,7 @@ inline void MapReduceKeepHighDim(TRValue<R, gpu, 1, DType> *dst,
   EShape eshape = expr::ShapeCheck<expr::ExpInfo<E>::kDim, E>
       ::Check(exp.self());
     Shape<1> dshape = expr::ShapeCheck<1, R>::Check(dst->self());
-  CHECK_EQ(eshape[dimkeep], dshape[0]) << "MapReduceKeepHighDim::reduction dimension do not match";
+  MSHADOW_CHECK_EQ(eshape[dimkeep], dshape[0]) << "MapReduceKeepHighDim::reduction dimension do not match";
   // use equvalent form
   Shape<4> pshape = Shape4(eshape.ProdShape(0, dimkeep),
                            eshape[dimkeep],

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -142,7 +142,8 @@ inline void MapReduceKeepHighDim(TRValue<R, gpu, 1, DType> *dst,
   EShape eshape = expr::ShapeCheck<expr::ExpInfo<E>::kDim, E>
       ::Check(exp.self());
     Shape<1> dshape = expr::ShapeCheck<1, R>::Check(dst->self());
-  MSHADOW_CHECK_EQ(eshape[dimkeep], dshape[0]) << "MapReduceKeepHighDim::reduction dimension do not match";
+  MSHADOW_CHECK_EQ(eshape[dimkeep], dshape[0])
+    << "MapReduceKeepHighDim::reduction dimension do not match";
   // use equvalent form
   Shape<4> pshape = Shape4(eshape.ProdShape(0, dimkeep),
                            eshape[dimkeep],


### PR DESCRIPTION
Since `mshadow` is a header library, I think it is a good idea to use different logging names (e.g. `MSHADOW_CHECK` instead of `CHECK`), especially when using it together with some customed logging headers whose names happen to be the same.
