### PR TITLE
Bugfix for MXNet Convolution operator with dilate param greater than 2 (part 1)

### DIFF
--- a/mshadow/extension/pack_col2patch.h
+++ b/mshadow/extension/pack_col2patch.h
@@ -44,9 +44,9 @@ struct PackColToPatchXExp:
        pdilate_y_(pdilate_y), pdilate_x_(pdilate_x){
     this->shape_ = imshape;
     const index_t o_height = (imshape[dstdim - 2] -
-        (pdilate_y == 1 ? psize_y : psize_y * pdilate_y - 1)) / pstride_y + 1;
+        (pdilate_y * ( psize_y - 1) + 1)) / pstride_y + 1;
     const index_t o_width  = (imshape[dstdim - 1] -
-        (pdilate_x == 1 ? psize_x : psize_x * pdilate_x - 1)) / pstride_x + 1;
+        (pdilate_x * ( psize_x - 1 ) + 1)) / pstride_x + 1;
     Shape<2> sshape = ShapeCheck<2, SrcExp>::Check(src_);
     CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
       << "PackColToPatchExp: src.size(1) mismatch";
@@ -109,10 +109,10 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
        psize_x_(e.psize_x_), pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.shape_[dstdim - 3]), pdilate_y_(e.pdilate_y_), pdilate_x_(e.pdilate_x_),
        i_height_(e.shape_[dstdim - 2]),
-       o_height_((e.shape_[dstdim - 2]  - (pdilate_y_ == 1 ?
-           psize_y_ : psize_y_ * pdilate_y_ - 1)) / pstride_y_ + 1),
-       o_width_((e.shape_[dstdim - 1]  - (pdilate_x_ == 1 ?
-           psize_x_ : psize_x_ * pdilate_x_ - 1)) / pstride_x_ + 1) {
+       o_height_((e.shape_[dstdim - 2] - (pdilate_y_ * (psize_y_ - 1) + 1)) /
+               pstride_y_ + 1),
+       o_width_((e.shape_[dstdim - 1] - (pdilate_x_ * (psize_x_ - 1) + 1)) /
+               pstride_x_ + 1) {
     // note: i/o convention are same as unpack
   }
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
@@ -123,8 +123,8 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
     const index_t n = idivh / i_channel_;
     const index_t x = j;
 
-    const index_t psize_y_dilate = (pdilate_y_ == 1 ? psize_y_ : psize_y_ * pdilate_y_ - 1);
-    const index_t psize_x_dilate = (pdilate_x_ == 1 ? psize_x_ : psize_x_ * pdilate_x_ - 1);
+    const index_t psize_y_dilate = (pdilate_y_ * ( psize_y_ - 1) + 1);
+    const index_t psize_x_dilate = (pdilate_x_ * ( psize_x_ - 1) + 1);
 
     const index_t py_min =
         y < psize_y_dilate ? y % pdilate_y_ : (y-psize_y_dilate + pstride_y_) / pstride_y_;

--- a/mshadow/extension/pack_col2patch.h
+++ b/mshadow/extension/pack_col2patch.h
@@ -44,9 +44,9 @@ struct PackColToPatchXExp:
        pdilate_y_(pdilate_y), pdilate_x_(pdilate_x){
     this->shape_ = imshape;
     const index_t o_height = (imshape[dstdim - 2] -
-        (pdilate_y * ( psize_y - 1) + 1)) / pstride_y + 1;
+        (pdilate_y * (psize_y - 1)+ 1))/pstride_y + 1;
     const index_t o_width  = (imshape[dstdim - 1] -
-        (pdilate_x * ( psize_x - 1 ) + 1)) / pstride_x + 1;
+        (pdilate_x * (psize_x - 1) + 1)) / pstride_x + 1;
     Shape<2> sshape = ShapeCheck<2, SrcExp>::Check(src_);
     CHECK_EQ(sshape[1], o_height * o_width * imshape.ProdShape(0, dstdim - 3))
       << "PackColToPatchExp: src.size(1) mismatch";
@@ -123,8 +123,8 @@ struct Plan<PackColToPatchXExp<SrcExp, DType, dstdim>, DType> {
     const index_t n = idivh / i_channel_;
     const index_t x = j;
 
-    const index_t psize_y_dilate = (pdilate_y_ * ( psize_y_ - 1) + 1);
-    const index_t psize_x_dilate = (pdilate_x_ * ( psize_x_ - 1) + 1);
+    const index_t psize_y_dilate = (pdilate_y_ * (psize_y_ - 1) + 1);
+    const index_t psize_x_dilate = (pdilate_x_ * (psize_x_ - 1) + 1);
 
     const index_t py_min =
         y < psize_y_dilate ? y % pdilate_y_ : (y-psize_y_dilate + pstride_y_) / pstride_y_;

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -59,16 +59,11 @@ struct UnpackPatchToColXExp:
     // calculate number of batches
     const index_t num = imshape.ProdShape(0, srcdim - 3);
     const index_t o_height = (i_height_ -
-        (pdilate_y == 1 ? psize_y : psize_y * pdilate_y - 1)) / pstride_y + 1;
+        (pdilate_y * (psize_y - 1) + 1)) / pstride_y + 1;
     const index_t o_width  = (i_width_  -
-        (pdilate_x == 1 ? psize_x : psize_x * pdilate_x - 1)) / pstride_x + 1;
+        (pdilate_x * (psize_x - 1) + 1)) / pstride_x + 1;
     this->shape_[1] = o_height * o_width * num;
     this->shape_[0] = psize_y * psize_x * i_channel_;
-    DBGLOG("UnpackPatch2ColXExp Constructed psize=" << psize_x << ","<< psize_y <<
-    		" stride=" << pstride_x_ << "," << pstride_y_ <<
-    		" dilate=" << pdilate_x_ << "," << pdilate_y_ <<
-    		" inshape=" << i_width_ << "," << i_height_ << "," << i_channel_ <<
-    		" outshape=" << o_width << "," << o_height << "," << num);
 
   }
 };
@@ -127,10 +122,8 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
        pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.i_channel_), pdilate_y_(e.pdilate_y_), pdilate_x_(e.pdilate_x_),
        i_height_(e.i_height_), i_width_(e.i_width_),
-       o_height_((i_height_  - (pdilate_y_ == 1 ?
-           psize_y_ : psize_y_ * pdilate_y_ - 1)) / pstride_y_ + 1),
-       o_width_((i_width_   - (pdilate_x_ == 1 ?
-           psize_x_ : psize_x_ * pdilate_x_ - 1)) / pstride_x_ + 1) {}
+       o_height_((i_height_  - (pdilate_y_ * (psize_y_ - 1 ) + 1)) / pstride_y_ + 1),
+       o_width_((i_width_   - (pdilate_x_ * (psize_x_ - 1) + 1)) / pstride_x_ + 1) {}
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
     const index_t x_offset = i % psize_x_ * pdilate_x_;
     const index_t idivp    = i / psize_x_;
@@ -142,11 +135,8 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
     const index_t n = jdivw / o_height_;
 
     if (x < i_width_ && y < i_height_) {
-      DBGLOG("UnpackPatchToColXExp: " << i << "," << j << " <= " << ((j % o_width_) * pstride_x_) << "+" << x_offset <<
-    		  "," << ((jdivw % o_height_) * pstride_y_) << "+" << y_offset << " chan=" << n);
       return src_.Eval((n * i_channel_  + c) * i_height_ + y, x);
     } else {
-      DBGLOG("UnpackPatchToColXExp: " << i << "," << j << " <= 0.0 :: OUT OF RANGE");
       return 0.0f;
     }
   }

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -64,7 +64,6 @@ struct UnpackPatchToColXExp:
         (pdilate_x * (psize_x - 1) + 1)) / pstride_x + 1;
     this->shape_[1] = o_height * o_width * num;
     this->shape_[0] = psize_y * psize_x * i_channel_;
-
   }
 };
 
@@ -122,8 +121,8 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
        pstride_y_(e.pstride_y_), pstride_x_(e.pstride_x_),
        i_channel_(e.i_channel_), pdilate_y_(e.pdilate_y_), pdilate_x_(e.pdilate_x_),
        i_height_(e.i_height_), i_width_(e.i_width_),
-       o_height_((i_height_  - (pdilate_y_ * (psize_y_ - 1 ) + 1)) / pstride_y_ + 1),
-       o_width_((i_width_   - (pdilate_x_ * (psize_x_ - 1) + 1)) / pstride_x_ + 1) {}
+       o_height_((i_height_ - (pdilate_y_ * (psize_y_ - 1) + 1)) / pstride_y_ + 1),
+       o_width_((i_width_ - (pdilate_x_ * (psize_x_ - 1) + 1)) / pstride_x_ + 1) {}
   MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
     const index_t x_offset = i % psize_x_ * pdilate_x_;
     const index_t idivp    = i / psize_x_;

--- a/mshadow/extension/unpack_patch2col.h
+++ b/mshadow/extension/unpack_patch2col.h
@@ -64,6 +64,12 @@ struct UnpackPatchToColXExp:
         (pdilate_x == 1 ? psize_x : psize_x * pdilate_x - 1)) / pstride_x + 1;
     this->shape_[1] = o_height * o_width * num;
     this->shape_[0] = psize_y * psize_x * i_channel_;
+    DBGLOG("UnpackPatch2ColXExp Constructed psize=" << psize_x << ","<< psize_y <<
+    		" stride=" << pstride_x_ << "," << pstride_y_ <<
+    		" dilate=" << pdilate_x_ << "," << pdilate_y_ <<
+    		" inshape=" << i_width_ << "," << i_height_ << "," << i_channel_ <<
+    		" outshape=" << o_width << "," << o_height << "," << num);
+
   }
 };
 
@@ -134,9 +140,13 @@ struct Plan<UnpackPatchToColXExp<SrcExp, DType, srcdim>, DType> {
     const index_t jdivw = j / o_width_;
     const index_t y = (jdivw % o_height_) * pstride_y_ + y_offset;
     const index_t n = jdivw / o_height_;
+
     if (x < i_width_ && y < i_height_) {
+      DBGLOG("UnpackPatchToColXExp: " << i << "," << j << " <= " << ((j % o_width_) * pstride_x_) << "+" << x_offset <<
+    		  "," << ((jdivw % o_height_) * pstride_y_) << "+" << y_offset << " chan=" << n);
       return src_.Eval((n * i_channel_  + c) * i_height_ + y, x);
     } else {
+      DBGLOG("UnpackPatchToColXExp: " << i << "," << j << " <= 0.0 :: OUT OF RANGE");
       return 0.0f;
     }
   }

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -15,6 +15,8 @@
 #include <iostream>
 #include "./base.h"
 #include "./expression.h"
+#include <iostream>
+#define DBGLOG(message) std::cout << "DEBUG::" << message << std::endl;
 
 namespace mshadow {
 /*! \brief device name CPU */

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -15,8 +15,6 @@
 #include <iostream>
 #include "./base.h"
 #include "./expression.h"
-#include <iostream>
-#define DBGLOG(message) std::cout << "DEBUG::" << message << std::endl;
 
 namespace mshadow {
 /*! \brief device name CPU */


### PR DESCRIPTION
Fixes issue with convolution if the dilate parameters are greater than two.

This PR is part of a fix for a bug in MXNet, 
see https://github.com/dmlc/mxnet/issues/1457

Important: Until the corresponding changes in MXNet are merged as well, these changes will break the convolution operator in MXNet for dilate parameters > 2.
