### PR TITLE
Add roi pooling as a tensor operation

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -8,6 +8,7 @@
 #define MSHADOW_CUDA_TENSOR_GPU_INL_CUH_
 #include "../tensor.h"
 #include "./reduce.cuh"
+#include "./tensor_gpu_roipooling-inl.cuh"
 
 namespace mshadow {
 namespace cuda {

--- a/mshadow/cuda/tensor_gpu_roipooling-inl.cuh
+++ b/mshadow/cuda/tensor_gpu_roipooling-inl.cuh
@@ -1,0 +1,238 @@
+#ifndef MSHADOW_CUDA_TENSOR_GPU_ROIPOOLING_INLINE_CU
+#define MSHADOW_CUDA_TENSOR_GPU_ROIPOOLING_INLINE_CU
+#include "../tensor.h"
+#include "./reduce.cuh"
+
+#define FRCNN_CUDA_CHECK(condition) \
+  /* Code block avoids redefinition of cudaError_t error */ \
+  do { \
+    cudaError_t error = condition; \
+    CHECK_EQ(error, cudaSuccess) << " " << cudaGetErrorString(error); \
+  } while (0)
+
+#define FRCNN_DIVUP(m,n) ((m) / (n) + ((m) % (n) > 0))
+#define FRCNN_NUM_THREADS 1024
+
+namespace mshadow {
+namespace cuda {
+
+template<typename Dtype>
+__global__ void ROIPoolForwardKernel(const int count, const Dtype* bottom_data,
+                                     const float spatial_scale, const int channels, const int height,
+                                     const int width, const int pooled_height, const int pooled_width,
+                                     const Dtype* bottom_rois, Dtype* top_data, Dtype* argmax_data) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x;
+       index < count;
+       index += blockDim.x * gridDim.x) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = bottom_rois[0];
+
+    if (roi_batch_ind < 0) {
+      top_data[index] = 0;
+      argmax_data[index] = 0;
+      continue;
+    }
+
+    int roi_start_w = round(bottom_rois[1] * spatial_scale);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale);
+
+    // Force malformed ROIs to be 1x1
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                       / static_cast<Dtype>(pooled_height);
+    Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                       / static_cast<Dtype>(pooled_width);
+
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                        * bin_size_h));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                        * bin_size_w));
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                     * bin_size_h));
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                     * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, 0), height);
+    hend = min(max(hend + roi_start_h, 0), height);
+    wstart = min(max(wstart + roi_start_w, 0), width);
+    wend = min(max(wend + roi_start_w, 0), width);
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    // Define an empty pooling region to be zero
+    Dtype maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    int maxidx = -1;
+    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        int bottom_index = h * width + w;
+        if (bottom_data[bottom_index] > maxval) {
+          maxval = bottom_data[bottom_index];
+          maxidx = bottom_index;
+        }
+      }
+    }
+    top_data[index] = maxval;
+    argmax_data[index] = (Dtype)maxidx;
+  }
+}
+
+template<typename Dtype>
+inline void ROIPoolForward(Tensor<gpu, 4, Dtype> &out,
+                           const Tensor<gpu, 4, Dtype> &data,
+                           const Tensor<gpu, 3, Dtype> &bbox,
+                           const Tensor<gpu, 4, Dtype> &max_idx,
+                           const float spatial_scale) {
+  const Dtype *bottom_data = data.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *top_data = out.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int count = out.shape_.Size();
+  const int channels = data.size(1);
+  const int height = data.size(2);
+  const int width = data.size(3);
+  const int pooled_height = out.size(2);
+  const int pooled_width = out.size(3);
+  dim3 dimGrid((count + FRCNN_NUM_THREADS - 1) / FRCNN_NUM_THREADS);
+  dim3 dimBlock(FRCNN_NUM_THREADS);
+  //CheckLaunchParam(dimGrid, dimBlock, "ROIPooling");
+  cudaStream_t stream = Stream<gpu>::GetStream(out.stream_);
+  ROIPoolForwardKernel<Dtype><<<dimGrid, dimBlock, 0, stream>>>(
+      count, bottom_data, spatial_scale, channels, height, width,
+      pooled_height, pooled_width, bottom_rois, top_data, argmax_data);
+  FRCNN_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+template<typename Dtype>
+__global__ void ROIPoolBackwardKernel(const int count, const Dtype* top_diff,
+                                      const Dtype* argmax_data, const int num_rois, const float spatial_scale,
+                                      const int channels, const int height, const int width,
+                                      const int pooled_height, const int pooled_width, Dtype* bottom_diff,
+                                      const Dtype* bottom_rois) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x;
+       index < count;
+       index += blockDim.x * gridDim.x) {
+    // (n, c, h, w) coords in bottom data
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+
+    Dtype gradient = 0;
+    // Accumulate gradient over all ROIs that pooled this element
+    for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+      const Dtype* offset_bottom_rois = bottom_rois + roi_n * 5;
+      int roi_batch_ind = offset_bottom_rois[0];
+      // Skip if ROI's batch index doesn't match n
+      if (n != roi_batch_ind) {
+        continue;
+      }
+
+      int roi_start_w = round(offset_bottom_rois[1] * spatial_scale);
+      int roi_start_h = round(offset_bottom_rois[2] * spatial_scale);
+      int roi_end_w = round(offset_bottom_rois[3] * spatial_scale);
+      int roi_end_h = round(offset_bottom_rois[4] * spatial_scale);
+
+      // Skip if ROI doesn't include (h, w)
+      const bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
+                           h >= roi_start_h && h <= roi_end_h);
+      if (!in_roi) {
+        continue;
+      }
+
+      int offset = (roi_n * channels + c) * pooled_height * pooled_width;
+      const Dtype* offset_top_diff = top_diff + offset;
+      const Dtype* offset_argmax_data = argmax_data + offset;
+
+      // Compute feasible set of pooled units that could have pooled
+      // this bottom unit
+
+      // Force malformed ROIs to be 1x1
+      int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+      int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+
+      Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                         / static_cast<Dtype>(pooled_height);
+      Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                         / static_cast<Dtype>(pooled_width);
+
+      int phstart = floor(static_cast<Dtype>(h - roi_start_h) / bin_size_h);
+      int phend = ceil(static_cast<Dtype>(h - roi_start_h + 1) / bin_size_h);
+      int pwstart = floor(static_cast<Dtype>(w - roi_start_w) / bin_size_w);
+      int pwend = ceil(static_cast<Dtype>(w - roi_start_w + 1) / bin_size_w);
+
+      phstart = min(max(phstart, 0), pooled_height);
+      phend = min(max(phend, 0), pooled_height);
+      pwstart = min(max(pwstart, 0), pooled_width);
+      pwend = min(max(pwend, 0), pooled_width);
+
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          if (round(offset_argmax_data[ph * pooled_width + pw]) == (h * width + w)) {
+            gradient += offset_top_diff[ph * pooled_width + pw];
+          }
+        }
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(Tensor<gpu, 4, Dtype> &in_grad,
+                            const Tensor<gpu, 4, Dtype> &out_grad,
+                            const Tensor<gpu, 3, Dtype> &bbox,
+                            const Tensor<gpu, 4, Dtype> &max_idx,
+                            const float spatial_scale) {
+  const Dtype *top_diff = out_grad.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *bottom_diff = in_grad.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int count = in_grad.shape_.Size();
+  const int num_rois = bbox.size(0);
+  const int channels = in_grad.size(1);
+  const int height = in_grad.size(2);
+  const int width = in_grad.size(3);
+  const int pooled_height = out_grad.size(2);
+  const int pooled_width = out_grad.size(3);
+  dim3 dimGrid((count + FRCNN_NUM_THREADS - 1) / FRCNN_NUM_THREADS);
+  dim3 dimBlock(FRCNN_NUM_THREADS);
+  //CheckLaunchParam(dimGrid, dimBlock, "ROIPooling");
+  cudaStream_t stream = Stream<gpu>::GetStream(in_grad.stream_);
+  ROIPoolBackwardKernel<Dtype><<<dimGrid, dimBlock, 0, stream>>>(
+      count, top_diff, argmax_data, num_rois, spatial_scale, channels, height, width,
+      pooled_height, pooled_width, bottom_diff, bottom_rois);
+  FRCNN_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+} // namespace cuda
+
+template<typename Dtype>
+inline void ROIPoolForward(Tensor<gpu, 4, Dtype> &out,
+                           const Tensor<gpu, 4, Dtype> &data,
+                           const Tensor<gpu, 3, Dtype> &bbox,
+                           const Tensor<gpu, 4, Dtype> &max_idx,
+                           const float spatial_scale) {
+  cuda::ROIPoolForward(out, data, bbox, max_idx, spatial_scale);
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(Tensor<gpu, 4, Dtype> &in_grad,
+                            const Tensor<gpu, 4, Dtype> &out_grad,
+                            const Tensor<gpu, 3, Dtype> &bbox,
+                            const Tensor<gpu, 4, Dtype> &max_idx,
+                            const float spatial_scale) {
+  cuda::ROIPoolBackward(in_grad, out_grad, bbox, max_idx, spatial_scale);
+}
+
+#endif  // MSHADOW_CUDA_TENSOR_GPU_ROIPOOLING_INLINE_CU

--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -11,6 +11,7 @@
 #include "./tensor.h"
 #include "./packet-inl.h"
 #include "./dot_engine-inl.h"
+#include "./tensor_cpu_roipooling-inl.h"
 
 namespace mshadow {
 template<>

--- a/mshadow/tensor_cpu_roipooling-inl.h
+++ b/mshadow/tensor_cpu_roipooling-inl.h
@@ -1,0 +1,205 @@
+#ifndef MSHADOW_TENSOR_CPU_ROIPOOLING_INLINE_H
+#define MSHADOW_TENSOR_CPU_ROIPOOLING_INLINE_H
+#include "./base.h"
+#include "./tensor.h"
+#include "./packet-inl.h"
+#include "./dot_engine-inl.h"
+#include <cassert>
+
+#define DIVUP(m,n) ((m) / (n) + ((m) % (n) > 0))
+
+using std::max;
+using std::min;
+using std::floor;
+using std::ceil;
+
+namespace mshadow {
+
+template<typename Dtype>
+inline void ROIPoolForward(Tensor<cpu, 4, Dtype> &out,
+                           const Tensor<cpu, 4, Dtype> &data,
+                           const Tensor<cpu, 3, Dtype> &bbox,
+                           const Tensor<cpu, 4, Dtype> &max_idx,
+                           const float spatial_scale_) {
+  const Dtype *bottom_data = data.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *top_data = out.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+  const int channels_ = data.size(1);
+  const int height_ = data.size(2);
+  const int width_ = data.size(3);
+  const int pooled_height_ = out.size(2);
+  const int pooled_width_ = out.size(3);
+
+  const int num_rois = bbox.size(0) * bbox.size(1);
+  const int batch_size = data.size(0);
+  const int data_size = data.size(1) * data.size(2) * data.size(3);
+  // For each ROI R = [batch_index x1 y1 x2 y2]: max pool over R
+  for (int n = 0; n < num_rois; ++n) {
+    int roi_batch_ind = bottom_rois[0];
+    int roi_start_w = round(bottom_rois[1] * spatial_scale_);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale_);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale_);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+    assert(roi_batch_ind >= 0);
+    assert(roi_batch_ind < batch_size);
+
+    // force malformed ROIs to be 1 * 1
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    const Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                             / static_cast<Dtype>(pooled_height_);
+    const Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                             / static_cast<Dtype>(pooled_width_);
+
+    const Dtype* batch_data = bottom_data + data_size * roi_batch_ind;
+
+    for (int c = 0; c < channels_; ++c) {
+      for (int ph = 0; ph < pooled_height_; ++ph) {
+        for (int pw = 0; pw < pooled_width_; ++pw) {
+          // Compute pooling region for this output unit:
+          //  start (included) = floor(ph * roi_height / pooled_height_)
+          //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
+          int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                              * bin_size_h));
+          int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                              * bin_size_w));
+          int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                           * bin_size_h));
+          int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                           * bin_size_w));
+
+          hstart = min(max(hstart + roi_start_h, 0), height_);
+          hend = min(max(hend + roi_start_h, 0), height_);
+          wstart = min(max(wstart + roi_start_w, 0), width_);
+          wend = min(max(wend + roi_start_w, 0), width_);
+
+          bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+          const int pool_index = ph * pooled_width_ + pw;
+          if (is_empty) {
+            top_data[pool_index] = 0;
+            argmax_data[pool_index] = -1;
+          }
+
+          for (int h = hstart; h < hend; ++h) {
+            for (int w = wstart; w < wend; ++w) {
+              const int index = h * width_ + w;
+              if (batch_data[index] > top_data[pool_index]) {
+                top_data[pool_index] = batch_data[index];
+                argmax_data[pool_index] = index;
+              }
+            }
+          }
+        }
+      }
+      // Increment all data pointers by one channel
+      batch_data += data.size(2) * data.size(3);
+      top_data += out.size(2) * out.size(3);
+      argmax_data += max_idx.size(2) * max_idx.size(3);
+    }
+    // Increment ROI data pointer
+    bottom_rois += bbox.size(2);
+  }
+
+  return;
+}
+
+template<typename Dtype>
+inline void ROIPoolBackward(Tensor<cpu, 4, Dtype> &in_grad,
+                            const Tensor<cpu, 4, Dtype> &out_grad,
+                            const Tensor<cpu, 3, Dtype> &bbox,
+                            const Tensor<cpu, 4, Dtype> &max_idx,
+                            const float spatial_scale_) {
+  const Dtype *top_diff = out_grad.dptr_;
+  const Dtype *bottom_rois = bbox.dptr_;
+  Dtype *bottom_diff = in_grad.dptr_;
+  Dtype *argmax_data = max_idx.dptr_;
+
+  const int batch_size_ = in_grad.size(0);
+  const int channels_ = in_grad.size(1);
+  const int height_ = in_grad.size(2);
+  const int width_ = in_grad.size(3);
+  const int pooled_height_ = out_grad.size(2);
+  const int pooled_width_ = out_grad.size(3);
+
+  const int num_rois = bbox.size(0) * bbox.size(1);
+
+  for (int b = 0; b < batch_size_; ++b) {
+    for (int c = 0; c < channels_; ++c) {
+      for (int h = 0; h < height_; ++h) {
+        for (int w = 0; w < width_; ++w) {
+          int offset_bottom_diff = (b * channels_ + c) * height_ * width_;
+          offset_bottom_diff += h * height_ + w;
+
+          Dtype gradient = 0;
+          // Accumulate gradient over all ROIs that pooled this element
+          for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+            int roi_batch_ind = bottom_rois[0];
+            assert(roi_batch_ind >= 0);
+            assert(roi_batch_ind < batch_size_);
+            if (b != roi_batch_ind) {
+              continue;
+            }
+
+            int roi_start_w = round(bottom_rois[1] * spatial_scale_);
+            int roi_start_h = round(bottom_rois[2] * spatial_scale_);
+            int roi_end_w = round(bottom_rois[3] * spatial_scale_);
+            int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+
+            bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
+                           h >= roi_start_h && h <= roi_end_h);
+            if (!in_roi) {
+              continue;
+            }
+
+            // force malformed ROIs to be 1 * 1
+            int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+            int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+            const Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                                     / static_cast<Dtype>(pooled_height_);
+            const Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                                     / static_cast<Dtype>(pooled_width_);
+
+            // compute pooled regions correspond to original (h, w) point
+            int phstart = static_cast<int>(floor(static_cast<Dtype>(h - roi_start_h)
+                                                 * bin_size_h));
+            int pwstart = static_cast<int>(floor(static_cast<Dtype>(w - roi_start_w)
+                                                 * bin_size_w));
+            int phend = static_cast<int>(ceil(static_cast<Dtype>(h - roi_start_h + 1)
+                                              * bin_size_h));
+            int pwend = static_cast<int>(ceil(static_cast<Dtype>(w - roi_start_w + 1)
+                                              * bin_size_w));
+
+            // clip to boundaries of pooled region
+            phstart = min(max(phstart, 0), pooled_height_);
+            phend = min(max(phend, 0), pooled_height_);
+            pwstart = min(max(pwstart, 0), pooled_width_);
+            pwend = min(max(pwend, 0), pooled_width_);
+
+            // accumulate over gradients in pooled regions
+            int offset = (roi_n * channels_ + c) * pooled_height_ * pooled_width_;
+            const Dtype* offset_top_diff = top_diff + offset;
+            const Dtype* offset_argmax_data = argmax_data + offset;
+            for (int ph = phstart; ph < phend; ++ph) {
+              for (int pw = pwstart; pw < pwend; ++pw) {
+                const int pooled_index = ph * pooled_width_ + pw;
+                if (h * width_ + w == round(offset_argmax_data[pooled_index])) {
+                  gradient += offset_top_diff[pooled_index];
+                }
+              }
+            }
+
+            // Increment ROI data pointer
+            bottom_rois += bbox.size(2);
+          }
+          bottom_diff[offset_bottom_diff] = gradient;
+        }
+      }
+    }
+  }
+}
+
+}  // namespace mshadow
+
+#endif  // MSHADOW_TENSOR_CPU_ROIPOOLING_INLINE_H


### PR DESCRIPTION
ROI Pooling projects bounding box proposals from data input layer to internal layer and pools to a manually set output size. As the pooling operation has fixed output size, it is not trivial to implement as cropping and pooling. See Fast R-CNN for more details.
Note that this implementation is a naive port from caffe code. Please point out a better and more unified way to do this in `mshadow` framework.
