### PR TITLE
Add broadcast_to

### DIFF
--- a/mshadow/extension/transpose.h
+++ b/mshadow/extension/transpose.h
@@ -57,7 +57,6 @@ template<typename SrcExp, typename DType, int etype>
 inline TransposeExExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>
 transpose(const Exp<SrcExp, DType, etype> &src, Shape<ExpInfo<SrcExp>::kDim> axes) {
   typedef ExpInfo<SrcExp> Info;
-  TypeCheckPass<Info::kDim >= 2>::Error_Expression_Does_Not_Meet_Dimension_Req();
   return TransposeExExp<SrcExp, DType, ExpInfo<SrcExp>::kDim>(src.self(), axes);
 }
 

--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -186,7 +186,8 @@ inline void MapExp(TRValue<R, cpu, dim, DType> *dst,
   Shape<dim> eshape = expr::ShapeCheck<dim, E>::Check(exp.self());
   Shape<dim> dshape = expr::ShapeCheck<dim, R>::Check(dst->self());
   CHECK(eshape[0] == 0 || eshape == dshape)
-      << "Assignment: Shape of Tensors are not consistent with target";
+      << "Assignment: Shape of Tensors are not consistent with target, "
+      << "eshape: " << eshape << " dshape:" << dshape;
   MapExpCPUEngine<expr::PacketCheck<E, MSHADOW_DEFAULT_PACKET>::kPass,
                   Saver, R, dim, DType, E, etype>
   ::Map(dst->ptrself(), exp);
@@ -399,8 +400,8 @@ inline void VectorDot(Tensor<Device, 1, DType> dst,
       << "VectorDot: Shape mismatch";
   CHECK_EQ(dst.size(0), 1)
       << "VectorDot: expect dst to be scalar";
-  expr::BLASEngine<Device>::SetStream(lhs.stream_);
-  mshadow::expr::BLASEngine<Device>::dot(
+  expr::BLASEngine<Device, DType>::SetStream(lhs.stream_);
+  mshadow::expr::BLASEngine<Device, DType>::dot(
       lhs.stream_, lhs.size(0), lhs.dptr_, 1, rhs.dptr_, 1, dst.dptr_);
 }
 }  // namespace mshadow

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -107,7 +107,8 @@ inline void MapExp(TRValue<R, gpu, dim, DType> *dst,
   Shape<dim> eshape = expr::ShapeCheck<dim, E>::Check(exp.self());
   Shape<dim> dshape = expr::ShapeCheck<dim, R>::Check(dst->self());
   CHECK(eshape[0] == 0 || eshape == dshape)
-    << "Assignment: Shape of Tensors are not consistent with target";
+    << "Assignment: Shape of Tensors are not consistent with target, "
+    << "eshape: " << eshape << " dshape:" << dshape;
   cuda::MapPlan<Saver>(MakePlan(dst->self()),
                        MakePlan(exp.self()),
                        dshape.FlatTo2D(),


### PR DESCRIPTION
In this PR:
1. Support `broadcast_multi_axes` and `broadcast_to` that can broadcast source tensor in multiple axes.
2. Fix DType in BlasEngine code in `tensor_cpu-inl.h`. The previous code has a bug that always uses float.
3. Revise logging.
