### PR TITLE
Fix static_cast problem

### DIFF
--- a/mshadow/extension/reduce_with_axis.h
+++ b/mshadow/extension/reduce_with_axis.h
@@ -116,7 +116,7 @@ struct Plan<ReduceWithAxisExp<Reducer, SrcExp, DType, dimsrc, mask, dimdst>, DTy
           idx = k;
         }
       }
-      return static_cast<DType>(idx);
+      return static_cast<DType>(static_cast<int>(idx));
     } else {
       DType res; Reducer::SetInitValue(res);
       for (index_t k = 0; k < size_; ++k) {


### PR DESCRIPTION
When I try to add DType support to reduce operators, the VS reports that it cannot directly cast index_t to DType. I find I need to first cast it to int before casting to DType.
