### PR TITLE
create scalar_exp of type half_t

### DIFF
--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -94,6 +94,9 @@ class half_t {
   MSHADOW_XINLINE explicit half_t(const double& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const uint8_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const int32_t& value) { constructor(value); }
+  MSHADOW_XINLINE explicit half_t(const uint32_t& value) { constructor(value); }
+  MSHADOW_XINLINE explicit half_t(const int64_t& value) { constructor(value); }
+  MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
 
   MSHADOW_HALF_CONVERSIONOP(float)
 

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -820,7 +820,7 @@ inline void VectorDot(Tensor<Device, 1, DType> dst,
 #include "./tensor_blob.h"
 #include "./random.h"
 // add definition of scalar related operators
-#ifdef MSAHDOW_SCALAR_
+#ifdef MSHADOW_SCALAR_
   #error "MSHADOW_SCALAR_ must not be defined"
 #endif
 // enumerate all the scalar data type we aim to be good at
@@ -831,6 +831,9 @@ inline void VectorDot(Tensor<Device, 1, DType> dst,
 #include "./expr_scalar-inl.h"
 #undef MSHADOW_SCALAR_
 #define MSHADOW_SCALAR_ int
+#include "./expr_scalar-inl.h"
+#undef MSHADOW_SCALAR_
+#define MSHADOW_SCALAR_ mshadow::half::half_t
 #include "./expr_scalar-inl.h"
 #undef MSHADOW_SCALAR_
 #endif  // MSHADOW_TENSOR_H_


### PR DESCRIPTION
Fixes a typo and adds half_t to the set of types that we generate scalar_expr for.
