### PR TITLE
Temp remove openmp flag

### DIFF
--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -142,8 +142,9 @@ inline void MapPlan(TRValue<R, cpu, dim, DType> *dst,
                     const expr::Plan<E, DType> &plan) {
   Shape<2> shape = expr::ShapeCheck<dim, R>::Check(dst->self()).FlatTo2D();
   expr::Plan<R, DType> dplan = expr::MakePlan(dst->self());
-  #pragma omp parallel for
-  for (int y = 0; y < static_cast<int>(shape[0]); ++y) {
+  // #pragma omp parallel for
+  // temp remove openmp, as default setting throttles CPU
+  for (index_t y = 0; y < shape[0]; ++y) {
     for (index_t x = 0; x < shape[1]; ++x) {
       // trust your compiler! -_- they will optimize it
       Saver::Save(dplan.REval(y, x), plan.Eval(y, x));


### PR DESCRIPTION
@sxjscience @hjk41 

I observed that with default omp on, the CPU usage of training is higher while without speed improvement. This can give pressure on CPU on machines with fewer cores. Therefore this line is removed. Let us think how we can add parallelization to places where it is needed. Note that not every place benefit from parallelization with all cores
