### PR TITLE
Accelerate AddTakeGrad + Support Sorting

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -21,6 +21,7 @@
 #include <cfloat>
 #include <climits>
 #include <algorithm>
+#include <functional>
 #include <sstream>
 #include <string>
 

--- a/mshadow/extension.h
+++ b/mshadow/extension.h
@@ -36,4 +36,5 @@
 #include "./extension/transpose.h"
 #include "./extension/flip.h"
 #include "./extension/complex.h"
+#include "./extension/range.h"
 #endif  // MSHADOW_EXTENSION_H_

--- a/mshadow/extension/range.h
+++ b/mshadow/extension/range.h
@@ -1,0 +1,99 @@
+/*!
+ *  Copyright (c) 2014 by Contributors
+ * \file range.h
+ * \brief support generating a range vector
+ * \author Xingjian Shi
+ */
+#ifndef MSHADOW_EXTENSION_RANGE_H_
+#define MSHADOW_EXTENSION_RANGE_H_
+
+#include "../extension.h"
+
+namespace mshadow {
+namespace expr {
+/*!
+ * \brief Generate a range vector similar to python: range(start, stop[, step][, repeat]).
+          If step is positive, the last element is the largest start + i * step less than stop
+          If step is negative, the last element is the smallest start + i * step greater than stop.
+          All elements are repeated for `repeat` times, e.g range(0, 4, 2, 3) --> 0, 0, 0, 2, 2, 2
+ * \tparam SrcExp type of lhs expression
+ * \tparam IndexExp type of index expression
+ * \tparam DType the type of elements
+ */
+template<typename DType>
+struct RangeExp:
+      public Exp<RangeExp<DType>, DType, type::kMapper> {
+  const int start_;
+  const int stop_;
+  const int step_;
+  const int repeat_;
+  /*! \brief constructor */
+  RangeExp(int start, int stop, int step, int repeat)
+      : start_(start), stop_(stop), step_(step), repeat_(repeat) {}
+};
+
+template<typename DType>
+inline RangeExp<DType>
+range(int start, int stop, int step = 1, int repeat = 1) {
+  return RangeExp<DType>(start, stop, step, repeat);
+}
+
+//----------------------
+// Execution plan
+//----------------------
+template<typename DType>
+struct Plan<RangeExp<DType>, DType> {
+ public:
+  explicit Plan(const RangeExp<DType> &e)
+      : start_(e.start_),
+        stop_(e.stop_),
+        step_(e.step_),
+        repeat_(e.repeat_) {
+  }
+  MSHADOW_XINLINE DType Eval(index_t y, index_t x) const {
+    return static_cast<DType>(start_ + (static_cast<int>(x) / repeat_) *  step_);
+  }
+
+ private:
+  const int start_;
+  const int stop_;
+  const int step_;
+  const int repeat_;
+};
+
+template<typename DType>
+inline Plan<RangeExp<DType>, DType>
+MakePlan(const RangeExp<DType> &exp) {
+  return Plan<RangeExp<DType>, DType>(exp);
+}
+
+template<int dim, typename DType>
+struct ShapeCheck<dim, RangeExp<DType> > {
+  inline static Shape<dim>
+  Check(const RangeExp<DType> &t) {
+    CHECK(dim == 1)
+        << "RangeExp only support 1 dimension output, received " << dim;
+    CHECK(t.step_ != 0)
+        << "RangeExp does not support step=0, received " << t.step_;
+    CHECK(t.repeat_ > 0)
+      << "RangeExp only supports repeat > 0, received " << t.repeat_;
+    if (t.step_ > 0) {
+      CHECK(t.start_ < t.stop_) << "RangeExp does not support (start, stop, step) = "
+                                << "(" << t.start_ << "," << t.stop_ << "," << t.step_ << ")";
+      return Shape1(t.repeat_ * ((t.stop_ - 1 - t.start_) / t.step_ + 1));
+    } else {
+      CHECK(t.start_ > t.stop_) << "RangeExp does not support (start, stop, step)= "
+                                << "(" << t.start_ << "," << t.stop_ << "," << t.step_ << ")";
+      return Shape1(t.repeat_ * ((t.start_ - 1 - t.stop_) / (- t.step_) + 1));
+    }
+  }
+};
+
+template<typename DType>
+struct ExpInfo<RangeExp<DType> > {
+  static const int kDim = 1;
+  static const int kDevMask = 0xffff;
+};
+}  // namespace expr
+}  // namespace mshadow
+#endif  // MSHADOW_EXTENSION_RANGE_H_

--- a/mshadow/extension/swapaxis.h
+++ b/mshadow/extension/swapaxis.h
@@ -7,6 +7,7 @@
 #ifndef MSHADOW_EXTENSION_SWAPAXIS_H_
 #define MSHADOW_EXTENSION_SWAPAXIS_H_
 #include <algorithm>
+#include <utility>
 #include "../extension.h"
 namespace mshadow {
 namespace expr {

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -671,7 +671,8 @@ inline void SoftmaxGrad(Tensor<gpu, 2, DType> dst,
                         const Tensor<gpu, 2, DType> &src,
                         const Tensor<gpu, 1, DType> &label);
 /*!
- * \brief CPU/GPU: dst += take_grad(index, src);
+ * \brief CPU/GPU: Gradient accumulate of embedding matrix. dst += take_grad(src, index)
+                   Called when the featuredim of src is much larger than the batchsize
  * \param dst destination
  * \param index index to take
  * \param src source output
@@ -681,7 +682,8 @@ inline void AddTakeGrad(Tensor<cpu, 2, DType> dst,
                         const Tensor<cpu, 1, IndexType>& index,
                         const Tensor<cpu, 2, DType> &src);
 /*!
- * \brief CPU/GPU: dst += take_grad(index, src);
+ * \brief CPU/GPU: Gradient accumulate of embedding matrix. dst += take_grad(src, index)
+                   Called when the featuredim of src is much larger than the batchsize
  * \param dst destination
  * \param index index to take
  * \param src source output
@@ -690,6 +692,60 @@ template<typename IndexType, typename DType>
 inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
                         const Tensor<gpu, 1, IndexType>& index,
                         const Tensor<gpu, 2, DType> &src);
+/*!
+ * \brief CPU/GPU: Gradient accumulate of embedding matrix. dst += take_grad(src, index)
+                   Called when the batchsize of src is larger than the featuredim
+ * \param dst destination
+ * \param sorted the sorted indices
+ * \param index original index of the sorted indices
+ * \param src source output
+ */
+template<typename IndexType, typename DType>
+inline void AddTakeGradLargeBatch(Tensor<cpu, 2, DType> dst,
+                                  const Tensor<gpu, 1, IndexType>& sorted,
+                                  const Tensor<cpu, 1, IndexType>& index,
+                                  const Tensor<cpu, 2, DType> &src);
+/*!
+ * \brief CPU/GPU: Gradient accumulate of embedding matrix. dst += take_grad(src, index)
+                   Called when the batchsize of src is larger than the featuredim
+ * \param dst destination
+ * \param sorted the sorted indices
+ * \param index original index of the sorted indices
+ * \param src source output
+ */
+template<typename IndexType, typename DType>
+inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
+                                  const Tensor<gpu, 1, IndexType>& sorted,
+                                  const Tensor<gpu, 1, IndexType>& index,
+                                  const Tensor<gpu, 2, DType> &src);
+/*!
+* \brief CPU/GPU: Sort key-value pairs stored in separate places. (Stable sort is performed!)
+* \param keys the keys to sort
+* \param values the values that sorts w.r.t the key
+* \param is_ascend whether to sort key in ascending order
+*/
+template<typename KDType, typename VDType>
+inline void SortByKey(Tensor<cpu, 1, KDType> keys, Tensor<cpu, 1, VDType> values,
+                      bool is_ascend = true);
+/*!
+ * \brief CPU/GPU: Sort key-value pairs stored in separate places. (Stable sort is performed!)
+ * \param keys the keys to sort
+ * \param values the values that sorts w.r.t the key
+ * \param is_ascend whether to sort key in ascending order
+ */
+template<typename KDType, typename VDType>
+inline void SortByKey(Tensor<gpu, 1, KDType> keys, Tensor<gpu, 1, VDType> values,
+                      bool is_ascend = true);
+/*!
+ * \brief CPU/GPU: Sort the keys within each segment. (Stable sort is performed!)
+                   Segments is defined as an ascending ordered vector like [0, 0, 0, 1, 1, 2, 3, 3, 3,...]
+                   We sort separately the keys labeled by 0 and 1, 2, 3, etc.
+                   Currently only supports sorting in ascending order !!
+ * \param values the data to sort
+ * \param segments segment indicator
+ */
+template<typename Device, typename VDType, typename SDType>
+inline void VectorizedSort(Tensor<Device, 1, VDType> values, Tensor<Device, 1, SDType> segments);
 
 // function declarations to support expression, no need to understand them
 // these functions do not need to be directly used

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -202,6 +202,19 @@ inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
                         const Tensor<gpu, 2, DType> &src) {
   cuda::AddTakeGrad(dst, index, src);
 }
+
+template<typename IndexType, typename DType>
+inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
+                                  const Tensor<gpu, 1, IndexType>& sorted,
+                                  const Tensor<gpu, 1, IndexType>& index,
+                                  const Tensor<gpu, 2, DType> &src) {
+  cuda::AddTakeGradLargeBatch(dst, sorted, index, src);
+}
+template<typename KDType, typename VDType>
+inline void SortByKey(Tensor<gpu, 1, KDType> keys, Tensor<gpu, 1, VDType> values,
+                      bool is_ascend) {
+  cuda::SortByKey(keys, values, is_ascend);
+}
 }  // namespace mshadow
 #endif  // __CUDACC__
 #endif  // MSHADOW_TENSOR_GPU_INL_H_


### PR DESCRIPTION
1. Add `range` operation to MShadow, which is similar to python's range
2. Accelerate the original `AddTakeGrad` using Torch's kernel, the backward pass of embedding layer will be much faster. https://github.com/dmlc/mxnet/issues/2612. I will make a PR to the MXNet side once it's merged.
3. Add two sort functions: `SortByKey` and `VectorizedSort`. The GPU side is implemented using Thrust. Also, sorting for `half_t` is currently not implemented. May add later.
