### PR TITLE
Fix get_seed in CXX11

### DIFF
--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -52,9 +52,8 @@ class Random<cpu, DType> {
   inline void Seed(int seed) {
 #if MSHADOW_IN_CXX11
     rnd_engine_.seed(seed);
-#else
-    this->rseed_ = static_cast<unsigned>(seed);
 #endif
+    this->rseed_ = static_cast<unsigned>(seed);
   }
   /*!
    * \brief get random seed used in random generator
@@ -151,6 +150,8 @@ class Random<cpu, DType> {
 #if MSHADOW_IN_CXX11
   /*! \brief use c++11 random engine. */
   std::mt19937 rnd_engine_;
+  /*! \brief random number seed used in random engine */
+  unsigned rseed_;
   // implementing generators.
   inline void GenUniform(DType *dptr, index_t size, DType a, DType b) {
     std::uniform_real_distribution<DType> dist_uniform(a, b);


### PR DESCRIPTION
The old version will fail when `MSHADOW_IN_CXX11` is on.
