### PR TITLE
Enable null ptr in workspace for BatchGEMM

### DIFF
--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -640,6 +640,7 @@ struct BLASEngine<gpu, double> {
                                   double **workspace) {
 #if defined(__CUDACC__) && CUDA_VERSION >= 4010
     // Cast DType* to DType** using workspace as a buffer
+    bool alloc_workspace = false;
     if (workspace == NULL) {
       // Allocate the workspace if it's NULL.
       // TODO(sxjscience) Try to move the allocation inside Tensor, which is thread-safe.

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -531,6 +531,13 @@ struct BLASEngine<gpu, float> {
                                   float **workspace) {
 #if defined(__CUDACC__) && CUDA_VERSION >= 4010
     // Cast DType* to DType** using workspace as a buffer
+    bool alloc_workspace = false;
+    if (workspace == NULL) {
+      // Allocate the workspace if it's NULL.
+      // TODO(sxjscience) Try to move the allocation inside Tensor, which is thread-safe.
+      cudaMalloc(reinterpret_cast<void**>(&workspace), 3 * batch_count * sizeof(float*));
+      alloc_workspace = true;
+    }
     GetBatchedView(workspace, const_cast<float*>(A), batch_count, m * k, stream);
     GetBatchedView(workspace + batch_count,
                    const_cast<float*>(B), batch_count, k * n, stream);
@@ -541,6 +548,9 @@ struct BLASEngine<gpu, float> {
                                             (const float**)(workspace + batch_count), ldb,
                                             &beta, workspace + 2 * batch_count, ldc, batch_count);
     CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: SgemmBatched fail";
+    if (alloc_workspace) {
+      cudaFree(workspace);
+    }
 #else
     for (int i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
@@ -630,6 +640,12 @@ struct BLASEngine<gpu, double> {
                                   double **workspace) {
 #if defined(__CUDACC__) && CUDA_VERSION >= 4010
     // Cast DType* to DType** using workspace as a buffer
+    if (workspace == NULL) {
+      // Allocate the workspace if it's NULL.
+      // TODO(sxjscience) Try to move the allocation inside Tensor, which is thread-safe.
+      cudaMalloc(reinterpret_cast<void**>(&workspace), 3 * batch_count * sizeof(double*));
+      alloc_workspace = true;
+    }
     GetBatchedView(workspace, const_cast<double*>(A), batch_count, m * k, stream);
     GetBatchedView(workspace + batch_count,
                    const_cast<double*>(B), batch_count, k * n, stream);
@@ -640,6 +656,9 @@ struct BLASEngine<gpu, double> {
                                             (const double**)(workspace + batch_count), ldb,
                                             &beta, workspace + 2 * batch_count, ldc, batch_count);
     CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: DgemmBatched fail";
+    if (alloc_workspace) {
+      cudaFree(workspace);
+    }
 #else
     for (int i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,


### PR DESCRIPTION
@winstywang Just a temporary workout.
We can now use workspace with NULL ptr like the following: 

``` c++
mshadow::Tensor<xpu, 1, real_t*> workspace(NULL, mshadow::Shape1(3 * out.size(0)), s);
if (kNullOp != req) {
  mshadow::BatchGEMM<false, false>(out, mlhs, mrhs, 1.0f,
                                   (kAddTo == req) ? 1.0f : 0.0f,
                                   workspace);
}
```
