### PR TITLE
fix the issue that libiomp5 cannot be found when compiling with mkl

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -41,6 +41,7 @@ ifneq ($(USE_INTEL_PATH), NONE)
 		MSHADOW_LDFLAGS += -L$(USE_INTEL_PATH)/lib
 	else
 		MSHADOW_LDFLAGS += -L$(USE_INTEL_PATH)/mkl/lib/intel64
+		MSHADOW_LDFLAGS += -L$(USE_INTEL_PATH)/compiler/lib/intel64
 		MSHADOW_LDFLAGS += -L$(USE_INTEL_PATH)/lib/intel64
 	endif
 	MSHADOW_CFLAGS += -I$(USE_INTEL_PATH)/mkl/include
@@ -51,7 +52,7 @@ ifeq ($(USE_INTEL_PATH), NONE)
 else
 	MKLROOT = $(USE_INTEL_PATH)/mkl
 endif
-	MSHADOW_LDFLAGS +=  -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a -Wl,--end-group -liomp5 -ldl -lpthread -lm
+	MSHADOW_LDFLAGS += -L${MKLROOT}/../compiler/lib/intel64 -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a -Wl,--end-group -liomp5 -ldl -lpthread -lm
 else
 	MSHADOW_LDFLAGS += -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5
 endif


### PR DESCRIPTION
When using full MKL package and USE_BLAS=mkl, compiling will fail that not found libiomp5. This fix this issue. 
