### PR TITLE
Add MSHADOW_FORCE_STREAM preprocessor define

### DIFF
--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -30,6 +30,7 @@ if(USE_CUDA)
 		message(FATAL_ERROR "-- CUDA is disabled.")
 	endif()
 	add_definitions(-DMSHADOW_USE_CUDA=1)
+	add_definitions(-DMSHADOW_FORCE_STREAM)
 	include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
     list(APPEND mshadow_LINKER_LIBS ${CUDA_CUDART_LIBRARY}
                               ${CUDA_curand_LIBRARY} ${CUDA_CUBLAS_LIBRARIES})


### PR DESCRIPTION
This change brings the CMake build closer to parity with the upstream Makefile, which unconditionally enables the MSHADOW_FORCE_STREAM preprocessor define at the MXNet level. This is kept within the USE_CUDA condition based on the assumption that it only impacts GPU training.

Please let me know if there is some reason that this define should exist at the MXNet level instead of mshadow.

I have verified that this produces a viable (and faster) build on Windows, Mac, and Linux.