### PR TITLE
fix bug in fedora building, use pkg to find find the right library name

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -65,7 +65,7 @@ endif
 ifeq ($(USE_BLAS), openblas)
 	MSHADOW_LDFLAGS += -lopenblas
 else ifeq ($(USE_BLAS), atlas)
-	MSHADOW_LDFLAGS += -lcblas
+	MSHADOW_LDFLAGS += $(shell pkg-config --libs atlas)
 else ifeq ($(USE_BLAS), blas)
 	MSHADOW_LDFLAGS += -lblas
 else ifeq ($(USE_BLAS), apple)


### PR DESCRIPTION
When i install atlas library in my fedora system, the library is built with the name libsatlas.so, not libcblas.so. so we will get link error.