### PR TITLE
fix the -G in cuda same effect in release

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -169,10 +169,6 @@ macro(mshadow_cuda_compile objlist_variable)
     list(APPEND CUDA_NVCC_FLAGS -Xcompiler -Wno-unused-function)
   endif()
   
-  if(NOT NDEBUG)
-    list(APPEND CUDA_NVCC_FLAGS -G)
-  endif()
-
   if(MSVC)
     # disable noisy warnings:
     # 4819: The file contains a character that cannot be represented in the current code page (number).


### PR DESCRIPTION
the `if(NOT NDEBUG)` is not good way.
this -G option move to mxnet\CMakeLists.txt