### PR TITLE
fix nvcc error with cuda 7.5

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -8,7 +8,12 @@ check_cxx_compiler_flag("-std=c++11"   SUPPORT_CXX11)
 
 # Known NVIDIA GPU achitectures mshadow can be compiled for.
 # This list will be used for CUDA_ARCH_NAME = All option
-set(mshadow_known_gpu_archs "20 21(20) 30 35 50 52 60 61")
+if(${CUDA_VERSION} GREATER 7.5)
+  set(mshadow_known_gpu_archs "20 21(20) 30 35 50 52 60 61")
+else()
+  set(mshadow_known_gpu_archs "20 21(20) 30 35 50 52")
+endif()
+
 
 ################################################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is enabled)


### PR DESCRIPTION
the "60 61" gpu archs not support with cuda 7.5.