### PR TITLE
New AddTakeGradLargeBatchKernel

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -8,6 +8,9 @@
 #define MSHADOW_CUDA_TENSOR_GPU_INL_CUH_
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_run_length_encode.cuh>
+#include <cub/device/device_scan.cuh>
 #if CUDA_VERSION >= 7000
 #include <thrust/system/cuda/execution_policy.h>
 #endif
@@ -41,6 +44,8 @@ const int kBaseThreadNum  = 1 << kBaseThreadBits;
 const int kMaxGridNum = 65535;
 /*! \brief suggested grid number for mapping kernel */
 const int kBaseGridNum = 1024;
+/*! \brief number of bytes memory arrays are expected to be aligned to */
+const int kMemAlignBytes = 256;
 /*! \brief get align stride for given size in x dimension */
 inline index_t GetAlignStride(index_t xsize) {
   if (xsize >= MSHADOW_MIN_PAD_RATIO * 32) {
@@ -49,6 +54,10 @@ inline index_t GetAlignStride(index_t xsize) {
     // if originally space is not aligned, no necessary to to alligned thread allocation
     return xsize;
   }
+}
+/*! \brief align memory array size */
+inline size_t AlignMemArraySize(const size_t size) {
+  return ((size + kMemAlignBytes - 1)/kMemAlignBytes)*kMemAlignBytes;
 }
 inline void CheckLaunchParam(dim3 dimGrid, dim3 dimBlock, const char *estr = "") {
   if (dimBlock.x * dimBlock.y * dimBlock.z > static_cast<unsigned>(kMaxThreadsPerBlock) ||
@@ -114,7 +123,6 @@ inline void MapPlan(expr::Plan<DstExp, DType> dst,
     MSHADOW_CUDA_POST_KERNEL_CHECK(MapPlanLargeKernel);
   }
 }
-
 template<typename Saver,typename Reducer, int warp_bits,
          typename DType, typename DstPlan, typename Plan>
 __global__ void MapRedKeepLowestKernel(DstPlan dst, Plan plan,
@@ -508,59 +516,150 @@ __global__ void AddTakeGradKernel(DstPlan dst,
   }
 }
 
-template<int warp_bits, int SZ, typename DType, typename IdxType>
+template<int SZ, typename DType, typename IdxType>
 __global__ void AddTakeGradLargeBatchKernel(DType* dst,
-                                            const IdxType *sorted, const IdxType *index, const DType *src,
-                                            int ymax, int xmax) {
-  // Based on Torch's Version https://github.com/torch/cunn/blob/master/lib/THCUNN/LookupTable.cu
-  // Each warp is responsible for an input into the LookupTable.
-  // If the preceeding input has the same as this input, then the warp
-  // exits immediately. The warp also processes subsequent inputs with the
-  // same value.
-  //
-  // Input Warp
-  // 1     <warp 1>
-  // 1     <warp 1> (<warp 2> exits without doing any work)
-  // 5     <warp 3>
-  // 8     <warp 4>
-  // Also, all warp will loop for SZ times to increase the throughput.
+                                           // If idx_start == NULL, then in-kernel edge
+                                           // detection is used
+                                           const IdxType *idx_start,
+                                           // idx_start_size_ptr ignored if idx_start == NULL
+                                           const int* idx_start_size_ptr,
+                                           const IdxType *sorted, const IdxType *index,
+                                           const DType *src,
+                                           int ymax, int xmax) {
+  // Size of the shared memory is [blockDim.x*SZ*blockDim.y]*sizeof(DType)
+  extern __shared__ char sh_grad_weight_char[];
+  DType* sh_grad_weight = (DType*)sh_grad_weight_char;
 
-  const int warp_size = 1 << warp_bits;
-  int idx = blockIdx.x * blockDim.y + threadIdx.y;
+  int iidx_end = (idx_start == NULL) ? ymax : *idx_start_size_ptr;
 
-  if (idx < ymax
-    && (idx == 0 || sorted[idx] != sorted[idx - 1])) {
-    do {
-      const int start_feature = threadIdx.x + blockIdx.y * blockDim.x * SZ;
-      const int dst_row = static_cast<int>(sorted[idx]) * xmax;
+  for (int iidx = blockIdx.y;iidx < iidx_end;iidx += gridDim.y) {
+
+    // Thread block sums up elements in the range [idx_begin, idx_end-1]
+    int idx_begin, idx_end;
+    int sorted_value;
+    if (idx_start == NULL) {
+      idx_begin = iidx;
+      sorted_value = static_cast<int>(sorted[idx_begin]);
+      if (idx_begin > 0 && sorted_value == static_cast<int>(sorted[idx_begin - 1])) continue;
+      // Algorithm is explained using an example:
+      //   blockDim.x = 32
+      //   blockDim.y = 4
+      //   sorted[idx_begin:] = [4 4 4 9]
+      //   (3,4) denotes threadIdx.x=3, threadIdx.y=4, ":" is used for ranges 
+      //   (0:31,0:3) sorted_value = 4
+      idx_end = idx_begin + 1;
+      unsigned int* sh_ballot = (unsigned int*)sh_grad_weight_char;
+      int no_edge = 0;
+      do {
+        int idx = idx_end + threadIdx.x + threadIdx.y*blockDim.x;
+        // Example:
+        //   (0:1,0) sorted_idx = 4
+        //   (rest)  sorted_idx = -1
+        int sorted_idx = (idx < ymax) ? static_cast<int>(sorted[idx]) : -1;
+        // Example:
+        //   (0:31,0) sh_ballot[0]     = 0b100
+        //   (rest)   sh_ballot[1...3] = 0
+        // sh_ballot[] tells us which thread within the warp found the edge
+        sh_ballot[threadIdx.y] = __ballot(sorted_value != sorted_idx);
+        __syncthreads();
+        // No edge if sh_ballot[threadIdx.x] == 0
+        // NOTE: All warps have the same value for no_edge
+        // Example:
+        //   (0,:)  no_edge = 0
+        //   (rest) no_edge = 1
+        no_edge = (threadIdx.x < blockDim.y) ? (sh_ballot[threadIdx.x] == 0) : 1;
+        idx_end += blockDim.x*blockDim.y;
+        // Example:
+        //   __all(no_edge) = 0 since no_edge = 0 for threadIdx.x = 0, hence we leave the loop
+      } while (__all(no_edge));
+      idx_end -= blockDim.x*blockDim.y;
+      // Find the first edge
+      // Example:
+      //   (0,:)  val = 1 << 0 = 1
+      //   (rest) val = 0
+      unsigned int val = (threadIdx.x < blockDim.y && sh_ballot[threadIdx.x] != 0) ?
+        (1 << threadIdx.x) : 0;
+      // NOTE: We do butterfly reduction on the entire warp width
+      //       so that all threads have the same result
+      // Example:
+      //   (all) val = 1
+      #pragma unroll
+      for (int i=warpSize/2;i>=1;i/=2) val |= __shfl_xor(val, i);
+      // __ffs() returns the position of first set bit, 1...32. __ffs(1) = 1
+      // j will be the warp index where edge was found
+      // Example:
+      //   (all) j = 1 - 1 = 0
+      int j = __ffs(val) - 1;
+      // j = warp index where the edge was found
+      // __ffs(sh_ballot[j]) - 1 = warp lane where the edge was found
+      // idx_end points to the one over the last value.
+      // Example:
+      //  idx_end += 0*blockDim.x + _ffs(0b100) - 1 = 0 + 3 - 1 = 2
+      //  sorted[idx_end] = 9
+      idx_end += j*blockDim.x + __ffs(sh_ballot[j]) - 1;
+      __syncthreads();
+    } else {
+      idx_begin = idx_start[iidx];
+      idx_end   = ((iidx + 1) < iidx_end) ? idx_start[iidx + 1] : ymax;
+      sorted_value = static_cast<int>(sorted[idx_begin]);
+    }
+
+    const int start_feature = threadIdx.x + blockIdx.x * blockDim.x * SZ;
+    const int dst_row = sorted_value * xmax;
+
+    int num_idx = idx_end - idx_begin;
+    int idx0 = idx_begin + threadIdx.y*num_idx/blockDim.y;
+    int idx1 = idx_begin + (threadIdx.y + 1)*num_idx/blockDim.y;
+
+    // Read and sum data into grad_weight[]
+    DType grad_weight[SZ];
+    #pragma unroll
+    for (int ii = 0; ii < SZ; ii++) {
+      grad_weight[ii] = (DType)0;
+    }
+    for (int idx=idx0; idx < idx1;idx++) {
       const int src_row = static_cast<int>(index[idx]) * xmax;
-      float grad_out[SZ];
-      float grad_weight[SZ];
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++)
       {
-        int feature_dim = start_feature + ii * warp_size;
+        int feature_dim = start_feature + ii * blockDim.x;
         if (feature_dim < xmax)
         {
-          grad_out[ii] = src[src_row + feature_dim];
-          grad_weight[ii] = dst[dst_row + feature_dim];
+          grad_weight[ii] += src[src_row + feature_dim];
         }
       }
-
+    }
+    #pragma unroll
+    for (int ii = 0; ii < SZ; ii++) {
+      sh_grad_weight[threadIdx.x + ii*blockDim.x + threadIdx.y*blockDim.x*SZ] = grad_weight[ii];
+    }
+    __syncthreads();
+    // We now have grad_weight[] values, reduce within thread block
+    for (int t=1;t < blockDim.y;t <<= 1) {
+      DType tmp[SZ];
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++) {
-        grad_weight[ii] += grad_out[ii];
+        tmp[ii] = (threadIdx.y + t < blockDim.y) ?
+          sh_grad_weight[threadIdx.x + ii*blockDim.x + (threadIdx.y + t)*blockDim.x*SZ] : (DType)0;
       }
-
+      __syncthreads();
       #pragma unroll
       for (int ii = 0; ii < SZ; ii++) {
-        int feature_dim = start_feature + ii * warp_size;
+        sh_grad_weight[threadIdx.x + ii*blockDim.x + threadIdx.y*blockDim.x*SZ] += tmp[ii];
+      }
+      __syncthreads();
+    }
+    // Result is in sh_grad_weight[threadIdx.x + ii*blockDim.x]
+    if (threadIdx.y == 0) {
+      #pragma unroll
+      for (int ii = 0; ii < SZ; ii++) {
+        int feature_dim = start_feature + ii * blockDim.x;
         if (feature_dim < xmax) {
-          dst[dst_row + feature_dim] = grad_weight[ii];
+          dst[dst_row + feature_dim] += sh_grad_weight[threadIdx.x + ii*blockDim.x];
         }
       }
-      idx++;
-    } while (idx < ymax && (sorted[idx] == sorted[idx - 1]));
+    }
+  
   }
 }
 
@@ -590,37 +689,128 @@ inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
   MSHADOW_CUDA_POST_KERNEL_CHECK(AddTakeGradKernel);
 }
 
+template<typename IndexType>
+inline size_t AddTakeGradLargeBatchWorkspaceSize(size_t num_items) {
+  size_t encode_bytes = 0;
+  cub::DeviceRunLengthEncode::Encode<IndexType*, IndexType*, IndexType*, int*>
+    (NULL, encode_bytes, NULL, NULL, NULL, NULL, num_items);
+  size_t exclusivesum_bytes = 0;
+  cub::DeviceScan::ExclusiveSum<IndexType*, IndexType*>(NULL, exclusivesum_bytes,
+    NULL, NULL, num_items);
+  size_t temporary_bytes = max(encode_bytes, exclusivesum_bytes);
+  size_t unique_align_bytes = AlignMemArraySize(num_items*sizeof(IndexType));
+  size_t counts_align_bytes = AlignMemArraySize(num_items*sizeof(IndexType));
+  size_t num_runs_align_bytes = AlignMemArraySize(1*sizeof(int));
+  size_t temporary_align_bytes = AlignMemArraySize(temporary_bytes);
+  return (unique_align_bytes + counts_align_bytes + num_runs_align_bytes + temporary_align_bytes);
+}
+
 template<typename IndexType, typename DType>
 inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
                                   const Tensor<gpu, 1, IndexType>& sorted,
                                   const Tensor<gpu, 1, IndexType>& index,
-                                  const Tensor<gpu, 2, DType> &src) {
+                                  const Tensor<gpu, 2, DType> &src,
+                                  Tensor<gpu, 1, char>* workspace) {
   CHECK_EQ(dst.CheckContiguous(), true);
   CHECK_EQ(sorted.CheckContiguous(), true);
   CHECK_EQ(index.CheckContiguous(), true);
   CHECK_EQ(src.CheckContiguous(), true);
   const int kWarpBits = kMemUnitBits;
-  const int SZ = 4;
-  const int block_dim_x = 1 << kWarpBits;
-  const int block_dim_y = 4;
-  const int grid_dim_x = (src.size(0) + block_dim_y - 1) / block_dim_y;
-  const int grid_dim_y = (src.size(1) + block_dim_x * SZ - 1) / (block_dim_x * SZ);
+  cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
+  IndexType* sum_counts_ptr = NULL;
+  int* num_runs_ptr = NULL;
+  if (dst.size(0)*4 < src.size(0) && workspace != NULL) {
+    // Workspace given and potentially loops at least 4 times, use CUB to create sum_counts
+    CHECK_EQ(workspace->CheckContiguous(), true);
+    // workspace = [unique_out, counts_out, temporary_storage]
+    size_t unique_align_bytes = AlignMemArraySize(sorted.size(0)*sizeof(IndexType));
+    size_t counts_align_bytes = AlignMemArraySize(sorted.size(0)*sizeof(IndexType));
+    size_t num_runs_align_bytes = AlignMemArraySize(1*sizeof(int));
+
+    size_t encode_bytes = 0;
+    cub::DeviceRunLengthEncode::Encode<IndexType*, IndexType*, IndexType*, int*>
+      (NULL, encode_bytes, NULL, NULL, NULL, NULL, sorted.size(0), stream);
+    size_t exclusivesum_bytes = 0;
+    cub::DeviceScan::ExclusiveSum<IndexType*, IndexType*>
+      (NULL, exclusivesum_bytes, NULL, NULL, sorted.size(0), stream);
+    size_t temporary_bytes = max(encode_bytes, exclusivesum_bytes);
+
+    // Check that we have enough storage
+    CHECK_GE(workspace->size(0), unique_align_bytes + counts_align_bytes + 
+      num_runs_align_bytes + temporary_bytes);
+
+    IndexType* unique_out_ptr = reinterpret_cast<IndexType*>(workspace->dptr_);
+    IndexType* counts_out_ptr = reinterpret_cast<IndexType*>(workspace->dptr_ + unique_align_bytes);
+    num_runs_ptr = reinterpret_cast<int*>(workspace->dptr_ + unique_align_bytes +
+      counts_align_bytes);
+    void* temporary_storage = reinterpret_cast<void *>(workspace->dptr_ + unique_align_bytes + 
+      counts_align_bytes + num_runs_align_bytes);
+
+    cub::DeviceRunLengthEncode::Encode<IndexType*, IndexType*, IndexType*, int*>
+    (temporary_storage, temporary_bytes, sorted.dptr_, unique_out_ptr, counts_out_ptr,
+      num_runs_ptr, sorted.size(0), stream);
+
+    sum_counts_ptr = unique_out_ptr;
+    cub::DeviceScan::ExclusiveSum<IndexType*, IndexType*>
+    (temporary_storage, temporary_bytes, counts_out_ptr, sum_counts_ptr,
+      sorted.size(0), stream);
+  }
+
+  const int num_unique_est = min(dst.size(0), src.size(0));
+  const int max_nthread = 128;
+  const int num_y = max(src.size(0)/num_unique_est, 1);
+  const int kWarpSize = (1 << kWarpBits);
+  const int block_dim_x = kWarpSize;
+  const int block_dim_y = min(num_y, max_nthread/block_dim_x);
+  const int SZ = min((src.size(1) + block_dim_x - 1) / block_dim_x, 4);
+  const int grid_dim_x = (src.size(1) + block_dim_x * SZ - 1) / (block_dim_x * SZ);
+  const int grid_dim_y = min(num_unique_est, kBaseGridNum);
   dim3 dimBlock(block_dim_x, block_dim_y);
   dim3 dimGrid(grid_dim_x, grid_dim_y);
+  // Maximum shared memory usage: 128*4*sizeof(DType), which is 4K for 64bit DType elements
+  int shmem_size = dimBlock.x*SZ*dimBlock.y*sizeof(DType);
 
   CHECK_EQ(dst.size(1), src.size(1)) << "AddTakeGradLargeBatch: shape mismatch";
   CHECK_EQ(index.size(0), src.size(0)) << "AddTakeGradLargeBatch: shape mismatch";
   CheckLaunchParam(dimGrid, dimBlock, "AddTakeGradLargeBatch");
-  cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
 
-  AddTakeGradLargeBatchKernel<kWarpBits, SZ, DType>
-      <<<dimGrid, dimBlock, 0, stream>>>
-      (dst.dptr_,
-       sorted.dptr_,
-       index.dptr_,
-       src.dptr_,
-       static_cast<int>(src.size(0)),
-       static_cast<int>(src.size(1)));
+  switch (SZ) {
+    case 1:
+    AddTakeGradLargeBatchKernel<1, DType>
+        <<<dimGrid, dimBlock, shmem_size, stream>>>
+        (dst.dptr_, sum_counts_ptr, num_runs_ptr,
+         sorted.dptr_, index.dptr_, src.dptr_,
+         static_cast<int>(src.size(0)),
+         static_cast<int>(src.size(1)));
+    break;
+    case 2:
+    AddTakeGradLargeBatchKernel<2, DType>
+        <<<dimGrid, dimBlock, shmem_size, stream>>>
+        (dst.dptr_, sum_counts_ptr, num_runs_ptr,
+         sorted.dptr_, index.dptr_, src.dptr_,
+         static_cast<int>(src.size(0)),
+         static_cast<int>(src.size(1)));
+    break;
+    case 3:
+    AddTakeGradLargeBatchKernel<3, DType>
+        <<<dimGrid, dimBlock, shmem_size, stream>>>
+        (dst.dptr_, sum_counts_ptr, num_runs_ptr,
+         sorted.dptr_, index.dptr_, src.dptr_,
+         static_cast<int>(src.size(0)),
+         static_cast<int>(src.size(1)));
+    break;
+    case 4:
+    AddTakeGradLargeBatchKernel<4, DType>
+        <<<dimGrid, dimBlock, shmem_size, stream>>>
+        (dst.dptr_, sum_counts_ptr, num_runs_ptr,
+         sorted.dptr_, index.dptr_, src.dptr_,
+         static_cast<int>(src.size(0)),
+         static_cast<int>(src.size(1)));
+    break;
+    default:
+    LOG(FATAL) << "AddTakeGradLargeBatch, incorrect value SZ " << SZ;
+    break;
+  }
   MSHADOW_CUDA_POST_KERNEL_CHECK(AddTakeGradLargeBatchKernel);
 }
 
@@ -665,22 +855,75 @@ inline void IndexFill(Tensor<gpu, 2, DType> dst,
 }
 
 template<typename KDType, typename VDType>
+inline size_t SortByKeyWorkspaceSize(size_t num_items) {
+  size_t sortpairs_bytes = 0;
+  cub::DeviceRadixSort::SortPairs<KDType, VDType>(NULL, sortpairs_bytes,
+      NULL, NULL, NULL, NULL, num_items);
+  size_t keys_align_bytes = AlignMemArraySize(num_items*sizeof(KDType));
+  size_t values_align_bytes = AlignMemArraySize(num_items*sizeof(VDType));
+  size_t sortpairs_align_bytes = AlignMemArraySize(sortpairs_bytes);
+  return (keys_align_bytes + values_align_bytes + sortpairs_align_bytes);
+}
+
+template<typename KDType, typename VDType>
 inline void SortByKey(Tensor<gpu, 1, KDType> keys, Tensor<gpu, 1, VDType> values,
-                      bool is_ascend) {
+                      bool is_ascend, Tensor<gpu, 1, char>* workspace,
+                      const int begin_bit, const int end_bit) {
   CHECK_EQ(keys.CheckContiguous(), true);
   CHECK_EQ(values.CheckContiguous(), true);
 #if CUDA_VERSION >= 7000
   cudaStream_t stream = Stream<gpu>::GetStream(keys.stream_);
-  thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
-  thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
-  if (is_ascend) {
-    thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::less<KDType>());
+  if (workspace != NULL) {
+    // Workspace given, sort using CUB
+    CHECK_EQ(workspace->CheckContiguous(), true);
+    // workspace = [keys_out, values_out, temporary_storage]
+    size_t keys_align_bytes = AlignMemArraySize(keys.size(0)*sizeof(KDType));
+    size_t values_align_bytes = AlignMemArraySize(keys.size(0)*sizeof(VDType));
+    // Get the size of internal storage (for checking purposes only)
+    size_t sortpairs_bytes = 0;
+    if (is_ascend) {
+      cub::DeviceRadixSort::SortPairs<KDType, VDType>(NULL, sortpairs_bytes,
+          NULL, NULL, NULL, NULL,
+          keys.size(0), begin_bit, end_bit, stream);
+    } else {
+      cub::DeviceRadixSort::SortPairsDescending<KDType, VDType>(NULL, sortpairs_bytes,
+          NULL, NULL, NULL, NULL,
+          keys.size(0), begin_bit, end_bit, stream);
+    }
+    // Check that we have enough storage
+    CHECK_GE(workspace->size(0), keys_align_bytes + values_align_bytes + sortpairs_bytes);
+    //
+    KDType* keys_out_ptr = reinterpret_cast<KDType *>(workspace->dptr_);
+    VDType* values_out_ptr = reinterpret_cast<VDType *>(workspace->dptr_ + keys_align_bytes);
+    void* temp_storage = reinterpret_cast<void *>(workspace->dptr_ + keys_align_bytes + values_align_bytes);
+    // Sort
+    if (is_ascend) {
+      cub::DeviceRadixSort::SortPairs(temp_storage, sortpairs_bytes,
+        keys.dptr_, keys_out_ptr, values.dptr_, values_out_ptr,
+        keys.size(0), begin_bit, end_bit, stream);
+    } else {
+      cub::DeviceRadixSort::SortPairsDescending(temp_storage, sortpairs_bytes,
+        keys.dptr_, keys_out_ptr, values.dptr_, values_out_ptr,
+        keys.size(0), begin_bit, end_bit, stream);
+    }
+    // Copy result back to [keys, values]
+    Tensor<gpu, 1, KDType> keys_out(keys_out_ptr, Shape1(keys.size(0)), keys.stream_);
+    Tensor<gpu, 1, VDType> values_out(values_out_ptr, Shape1(keys.size(0)), keys.stream_);
+    Copy(keys, keys_out, keys.stream_);
+    Copy(values, values_out, values.stream_);
   } else {
-    thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::greater<KDType>());
+    // No workspace, sort using thrust
+    thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
+    thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
+    if (is_ascend) {
+      thrust::stable_sort_by_key(
+        thrust::cuda::par.on(stream),
+        key_iter, key_iter + keys.size(0), value_iter, thrust::less<KDType>());
+    } else {
+      thrust::stable_sort_by_key(
+        thrust::cuda::par.on(stream),
+        key_iter, key_iter + keys.size(0), value_iter, thrust::greater<KDType>());
+    }
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -790,6 +790,18 @@ inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
                         const Tensor<gpu, 1, IndexType>& index,
                         const Tensor<gpu, 2, DType> &src);
 /*!
+ * \brief CPU/GPU: Return the amount of temporary storage in bytes required by AddTakeGradLargeBatch
+ * \param num_items number of keys
+ */
+template<typename IndexType>
+inline size_t AddTakeGradLargeBatchWorkspaceSize(size_t num_items, const cpu& dummy);
+/*!
+ * \brief CPU/GPU: Return the amount of temporary storage in bytes required by AddTakeGradLargeBatch
+ * \param num_items number of keys
+ */
+template<typename IndexType>
+inline size_t AddTakeGradLargeBatchWorkspaceSize(size_t num_items, const gpu& dummy);
+/*!
  * \brief CPU/GPU: Gradient accumulate of embedding matrix.
                    dst[sorted[i]] += src[index[i]]
                    Called when the batchsize of src is larger than the featuredim
@@ -800,9 +812,10 @@ inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
  */
 template<typename IndexType, typename DType>
 inline void AddTakeGradLargeBatch(Tensor<cpu, 2, DType> dst,
-                                  const Tensor<gpu, 1, IndexType>& sorted,
+                                  const Tensor<cpu, 1, IndexType>& sorted,
                                   const Tensor<cpu, 1, IndexType>& index,
-                                  const Tensor<cpu, 2, DType> &src);
+                                  const Tensor<cpu, 2, DType> &src,
+                                  Tensor<cpu, 1, char>* workspace = NULL);
 /*!
  * \brief CPU/GPU: Gradient accumulate of embedding matrix.
                    dst[sorted[i]] += src[index[i]]
@@ -816,7 +829,8 @@ template<typename IndexType, typename DType>
 inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
                                   const Tensor<gpu, 1, IndexType>& sorted,
                                   const Tensor<gpu, 1, IndexType>& index,
-                                  const Tensor<gpu, 2, DType> &src);
+                                  const Tensor<gpu, 2, DType> &src,
+                                  Tensor<gpu, 1, char>* workspace = NULL);
 /*!
  * \brief CPU/GPU: Fill the values of the destination matrix to specific rows in the source matrix.
                    dst[index[i]] = src[i]
@@ -849,7 +863,8 @@ inline void IndexFill(Tensor<gpu, 2, DType> dst,
  */
 template<typename KDType, typename VDType>
 inline void SortByKey(Tensor<cpu, 1, KDType> keys, Tensor<cpu, 1, VDType> values,
-                      bool is_ascend = true);
+                      bool is_ascend = true, Tensor<cpu, 1, char>* workspace = NULL,
+                      const int begin_bit = 0, const int end_bit = sizeof(KDType)*8);
 /*!
  * \brief CPU/GPU: Sort key-value pairs stored in separate places. (Stable sort is performed!)
  * \param keys the keys to sort
@@ -858,7 +873,26 @@ inline void SortByKey(Tensor<cpu, 1, KDType> keys, Tensor<cpu, 1, VDType> values
  */
 template<typename KDType, typename VDType>
 inline void SortByKey(Tensor<gpu, 1, KDType> keys, Tensor<gpu, 1, VDType> values,
-                      bool is_ascend = true);
+                      bool is_ascend = true, Tensor<gpu, 1, char>* workspace = NULL,
+                      const int begin_bit = 0, const int end_bit = sizeof(KDType)*8);
+/*!
+ * \brief CPU/GPU: Align memory array size
+ * \param size size of the array
+ */
+template<typename xpu>
+inline size_t AlignMemArraySize(const size_t size);
+/*!
+ * \brief CPU/GPU: Return the amount of temporary storage in bytes required for SortByKey
+ * \param num_keys number of keys to sort
+ */
+template<typename KDType, typename VDType>
+inline size_t SortByKeyWorkspaceSize(size_t num_keys, const cpu& dummy);
+/*!
+ * \brief CPU/GPU: Return the amount of temporary storage in bytes required for SortByKey
+ * \param num_keys number of keys to sort
+ */
+template<typename KDType, typename VDType>
+inline size_t SortByKeyWorkspaceSize(size_t num_keys, const gpu& dummy);
 /*!
  * \brief CPU/GPU: Sort the keys within each segment. (Stable sort is performed!)
                    Segments is defined as an ascending ordered vector like [0, 0, 0, 1, 1, 2, 3, 3, 3,...]

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -203,18 +203,35 @@ inline void AddTakeGrad(Tensor<gpu, 2, DType> dst,
   cuda::AddTakeGrad(dst, index, src);
 }
 
+template<typename IndexType>
+inline size_t AddTakeGradLargeBatchWorkspaceSize(size_t num_items, const gpu& dummy) {
+  return cuda::AddTakeGradLargeBatchWorkspaceSize<IndexType>(num_items);
+}
+
 template<typename IndexType, typename DType>
 inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
                                   const Tensor<gpu, 1, IndexType>& sorted,
                                   const Tensor<gpu, 1, IndexType>& index,
-                                  const Tensor<gpu, 2, DType> &src) {
-  cuda::AddTakeGradLargeBatch(dst, sorted, index, src);
+                                  const Tensor<gpu, 2, DType> &src,
+                                  Tensor<gpu, 1, char>* workspace) {
+  cuda::AddTakeGradLargeBatch(dst, sorted, index, src, workspace);
 }
 
 template<typename KDType, typename VDType>
 inline void SortByKey(Tensor<gpu, 1, KDType> keys, Tensor<gpu, 1, VDType> values,
-                      bool is_ascend) {
-  cuda::SortByKey(keys, values, is_ascend);
+                      bool is_ascend, Tensor<gpu, 1, char>* workspace,
+                      const int begin_bit, const int end_bit) {
+  cuda::SortByKey(keys, values, is_ascend, workspace, begin_bit, end_bit);
+}
+
+template<typename KDType, typename VDType>
+inline size_t SortByKeyWorkspaceSize(size_t num_items, const gpu& dummy) {
+  return cuda::SortByKeyWorkspaceSize<KDType, VDType>(num_items);
+}
+
+template<>
+inline size_t AlignMemArraySize<gpu>(const size_t size) {
+  return cuda::AlignMemArraySize(size);
 }
 
 template<typename IndexType, typename DType>


### PR DESCRIPTION
Implements new faster AddTakeGradLargeBatchKernel and switches to using CUB for sorting instead of Thrust. Reason for abandoning Thrust is that it introduces cudaMalloc() calls into runtime that are hard to avoid. 