### PR TITLE
fix typo in mshadow.mk

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -108,6 +108,6 @@ else
 	MSHADOW_CFLAGS+= -DMSHADOW_DIST_PS=0
 endif
 
-# Set MSDHADOW_USE_PASCAL to one to enable nvidia pascal gpu features.
+# Set MSHADOW_USE_PASCAL to one to enable nvidia pascal gpu features.
 # Like cublasHgemm
-MSHADOW_CFLAGS += -DMSDHADOW_USE_PASCAL=0
+MSHADOW_CFLAGS += -DMSHADOW_USE_PASCAL=0


### PR DESCRIPTION
fix typo in mshadow.mk (#185)

`MSDHADOW_USE_PASCAL` --> `MSHADOW_USE_PASCAL`

