### PR TITLE
add -std=c++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   matrix:
     - TASK=lint LINT_LANG=cpp
     - TASK=doc
-    - TASK=build CXX=g++
+    - TASK=build CXX=clang++
 
 # dependent apt packages
 addons:

--- a/guide/Makefile
+++ b/guide/Makefile
@@ -1,6 +1,8 @@
 # set LD_LIBRARY_PATH
 export CC  = gcc
+ifndef CXX
 export CXX = g++
+endif
 export NVCC =nvcc
 include config.mk
 include ../make/mshadow.mk

--- a/guide/Makefile
+++ b/guide/Makefile
@@ -4,7 +4,7 @@ export CXX = g++
 export NVCC =nvcc
 include config.mk
 include ../make/mshadow.mk
-export CFLAGS = -Wall -O3 -I../ $(MSHADOW_CFLAGS)
+export CFLAGS = -std=c++11 -Wall -O3 -I../ $(MSHADOW_CFLAGS)
 export LDFLAGS= -lm $(MSHADOW_LDFLAGS)
 export NVCCFLAGS = -O3 --use_fast_math -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 


### PR DESCRIPTION
Add option `-std=c++11` otherwise `guide/` won't make.

In order to make this pass Travis tests, I had to change the default C++ compiler to `clang++` so that it'd recognise the latest compilation options. The `g++` bundled in the Travis container is of an old version circa 3.7.

In `guide/Makefile` we won't export again `CXX` if it's already defined.