### PR TITLE
Fixed ConverLayout(Shape3) warnings in MXNet build

### DIFF
--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -262,19 +262,18 @@ inline Shape<3> ConvertLayout(const Shape<3>& src, int src_layout, int dst_layou
   default:
     LOG(FATAL) << "Invalid layout for 3d shape " << src_layout;
   }
-  Shape<3> dst2;
   switch (dst_layout) {
   case kNCW:
     return dst;
   case kNWC:
-    dst2[0] = dst[0];
-    dst2[1] = dst[2];
-    dst2[2] = dst[1];
+    dst[1] = dst[1] ^ dst[2];
+    dst[2] = dst[1] ^ dst[2];
+    dst[1] = dst[1] ^ dst[2];
     break;
   default:
     LOG(FATAL) << "Invalid layout for 3d shape " << src_layout;
   }
-  return dst2;
+  return dst;
 }
 
 /*!

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -266,9 +266,11 @@ inline Shape<3> ConvertLayout(const Shape<3>& src, int src_layout, int dst_layou
   case kNCW:
     return dst;
   case kNWC:
-    dst[1] = dst[1] ^ dst[2];
-    dst[2] = dst[1] ^ dst[2];
-    dst[1] = dst[1] ^ dst[2];
+    {
+      index_t tmp = dst[1];
+      dst[1] = dst[2];
+      dst[2] = tmp;
+    }
     break;
   default:
     LOG(FATAL) << "Invalid layout for 3d shape " << src_layout;


### PR DESCRIPTION
This PR fixed compiler warnings on ConverLayout(Shape3) in MXNet