### PR TITLE
half2 type

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -266,7 +266,6 @@ enum TypeFlag {
   kFloat32,
   kFloat64,
   kFloat16,
-  kFloat16x2,
   kUint8,
   kInt32
 };
@@ -658,79 +657,41 @@ struct minimum {
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
 
-#ifdef __CUDACC__
-#define MSHADOW_TYPE_SWITCH2(type, DType, ...)      \
-  switch (type) {                                   \
-  case mshadow::kFloat32:                           \
-    {                                               \
-      typedef float DType;                          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat64:                           \
-    {                                               \
-      typedef double DType;                         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat16:                           \
-    {                                               \
-      typedef mshadow::half::half2_t DType;         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kUint8:                             \
-    {                                               \
-      typedef uint8_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt32:                             \
-    {                                               \
-      typedef int32_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type;     \
+#define MSHADOW_TYPE_SWITCH_WITH_HALF2(type, DType, ...)  \
+  switch (type) {                                         \
+  case mshadow::kFloat32:                                 \
+    {                                                     \
+      typedef float DType;                                \
+      {__VA_ARGS__}                                       \
+    }                                                     \
+    break;                                                \
+  case mshadow::kFloat64:                                 \
+    {                                                     \
+      typedef double DType;                               \
+      {__VA_ARGS__}                                       \
+    }                                                     \
+    break;                                                \
+  case mshadow::kFloat16:                                 \
+    {                                                     \
+      typedef mshadow::half::half2_t DType;               \
+      {__VA_ARGS__}                                       \
+    }                                                     \
+    break;                                                \
+  case mshadow::kUint8:                                   \
+    {                                                     \
+      typedef uint8_t DType;                              \
+      {__VA_ARGS__}                                       \
+    }                                                     \
+    break;                                                \
+  case mshadow::kInt32:                                   \
+    {                                                     \
+      typedef int32_t DType;                              \
+      {__VA_ARGS__}                                       \
+    }                                                     \
+    break;                                                \
+  default:                                                \
+    LOG(FATAL) << "Unknown type enum " << type;           \
   }
-#else
-#define MSHADOW_TYPE_SWITCH2(type, DType, ...)       \
-  switch (type) {                                   \
-  case mshadow::kFloat32:                           \
-    {                                               \
-      typedef float DType;                          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat64:                           \
-    {                                               \
-      typedef double DType;                         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kFloat16:                           \
-    {                                               \
-      typedef mshadow::half::half_t DType;          \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kUint8:                             \
-    {                                               \
-      typedef uint8_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt32:                             \
-    {                                               \
-      typedef int32_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  default:                                          \
-    LOG(FATAL) << "Unknown type enum " << type;     \
-  }
-#endif
 
 #define MSHADOW_REAL_TYPE_SWITCH(type, DType, ...)  \
   switch (type) {                                   \

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -239,6 +239,7 @@ extern "C" {
   }
 
 #include "./half.h"
+#include "./half2.h"
 #include "./logging.h"
 /*! \brief namespace for mshadow */
 namespace mshadow {
@@ -265,6 +266,7 @@ enum TypeFlag {
   kFloat32,
   kFloat64,
   kFloat16,
+  kFloat16x2,
   kUint8,
   kInt32
 };
@@ -295,6 +297,10 @@ struct DataType<half::half_t> {
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_HALF;
   typedef float ScaleType;
 #endif
+};
+template<>
+struct DataType<half::half2_t> {
+  static const int kFlag = kFloat16;
 };
 template<>
 struct DataType<uint8_t> {
@@ -645,6 +651,80 @@ struct minimum {
   default:                                          \
     LOG(FATAL) << "Unknown type enum " << type;     \
   }
+
+#ifdef __CUDACC__
+#define MSHADOW_TYPE_SWITCH2(type, DType, ...)      \
+  switch (type) {                                   \
+  case mshadow::kFloat32:                           \
+    {                                               \
+      typedef float DType;                          \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat64:                           \
+    {                                               \
+      typedef double DType;                         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat16:                           \
+    {                                               \
+      typedef mshadow::half::half2_t DType;         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kUint8:                             \
+    {                                               \
+      typedef uint8_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt32:                             \
+    {                                               \
+      typedef int32_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown type enum " << type;     \
+  }
+#else
+#define MSHADOW_TYPE_SWITCH2(type, DType, ...)       \
+  switch (type) {                                   \
+  case mshadow::kFloat32:                           \
+    {                                               \
+      typedef float DType;                          \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat64:                           \
+    {                                               \
+      typedef double DType;                         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kFloat16:                           \
+    {                                               \
+      typedef mshadow::half::half_t DType;          \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kUint8:                             \
+    {                                               \
+      typedef uint8_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt32:                             \
+    {                                               \
+      typedef int32_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown type enum " << type;     \
+  }
+#endif
 
 #define MSHADOW_REAL_TYPE_SWITCH(type, DType, ...)  \
   switch (type) {                                   \

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -277,7 +277,7 @@ struct DataType;
 template<>
 struct DataType<float> {
   static const int kFlag = kFloat32;
-  static const int kPack = 1;
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_32F;
 #if MSHADOW_USE_CUDNN
@@ -289,7 +289,7 @@ struct DataType<float> {
 template<>
 struct DataType<double> {
   static const int kFlag = kFloat64;
-  static const int kPack = 1;
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_64F;
 #if MSHADOW_USE_CUDNN
@@ -301,7 +301,7 @@ struct DataType<double> {
 template<>
 struct DataType<half::half_t> {
   static const int kFlag = kFloat16;
-  static const int kPack = 1;
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_16F;
 #if MSHADOW_USE_CUDNN
@@ -313,12 +313,12 @@ struct DataType<half::half_t> {
 template<>
 struct DataType<half::half2_t> {
   static const int kFlag = kFloat16;
-  static const int kPack = 2;
+  static const int kLanes = 2;
 };
 template<>
 struct DataType<uint8_t> {
   static const int kFlag = kUint8;
-  static const int kPack = 1;
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_8U;
 #if (MSHADOW_USE_CUDNN == 1 && CUDNN_MAJOR >= 6)
@@ -331,6 +331,7 @@ struct DataType<uint8_t> {
 template<>
 struct DataType<int8_t> {
   static const int kFlag = kInt8;
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_8I;
 #if (MSHADOW_USE_CUDNN == 1 && CUDNN_MAJOR >= 6)
@@ -338,14 +339,11 @@ struct DataType<int8_t> {
   typedef int8_t ScaleType;
 #endif
 #endif
->>>>>>> origin/master
 };
 template<>
 struct DataType<int32_t> {
   static const int kFlag = kInt32;
-<<<<<<< HEAD
-  static const int kPack = 1;
-=======
+  static const int kLanes = 1;
 #if MSHADOW_USE_CUDA
   static const cudaDataType_t kCudaFlag = CUDA_R_32I;
 #if (MSHADOW_USE_CUDNN == 1 && CUDNN_MAJOR >= 6)
@@ -353,7 +351,6 @@ struct DataType<int32_t> {
   typedef int32_t ScaleType;
 #endif
 #endif
->>>>>>> origin/master
 };
 
 /*! \brief type enum value for default real type */

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -277,6 +277,7 @@ struct DataType;
 template<>
 struct DataType<float> {
   static const int kFlag = kFloat32;
+  static const int kPack = 1;
 #if (MSHADOW_USE_CUDA && MSHADOW_USE_CUDNN == 1)
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_FLOAT;
   typedef float ScaleType;
@@ -285,6 +286,7 @@ struct DataType<float> {
 template<>
 struct DataType<double> {
   static const int kFlag = kFloat64;
+  static const int kPack = 1;
 #if (MSHADOW_USE_CUDA && MSHADOW_USE_CUDNN == 1)
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_DOUBLE;
   typedef double ScaleType;
@@ -293,6 +295,7 @@ struct DataType<double> {
 template<>
 struct DataType<half::half_t> {
   static const int kFlag = kFloat16;
+  static const int kPack = 1;
 #if (MSHADOW_USE_CUDA && MSHADOW_USE_CUDNN == 1)
   static const cudnnDataType_t kCudnnFlag = CUDNN_DATA_HALF;
   typedef float ScaleType;
@@ -301,14 +304,17 @@ struct DataType<half::half_t> {
 template<>
 struct DataType<half::half2_t> {
   static const int kFlag = kFloat16;
+  static const int kPack = 2;
 };
 template<>
 struct DataType<uint8_t> {
   static const int kFlag = kUint8;
+  static const int kPack = 1;
 };
 template<>
 struct DataType<int32_t> {
   static const int kFlag = kInt32;
+  static const int kPack = 1;
 };
 
 /*! \brief type enum value for default real type */

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -11,16 +11,16 @@
 #if (defined(__CUDACC__) && __CUDA_ARCH__ >= 530 && MSHADOW_USE_CUDA && CUDA_VERSION >= 7050)
   #define MSHADOW_CUDA_HALF2 1
   #include <cuda_fp16.h>
+  #define MSHADOW_HALF2_INLINE MSHADOW_FORCE_INLINE __device__
 #else
   #define MSHADOW_CUDA_HALF2 0
+  #define MSHADOW_HALF2_INLINE MSHADOW_FORCE_INLINE
 #endif
 
 /*! \brief namespace for mshadow */
 namespace mshadow {
 /* \brief name space for host/device portable half-precision floats */
 namespace half {
-
-#define MSHADOW_HALF2_INLINE MSHADOW_FORCE_INLINE __device__
 
 #define MSHADOW_HALF2_ASSIGNOP(AOP, OP)                                   \
   template<typename T>                                                    \
@@ -29,7 +29,7 @@ namespace half {
   }                                                                       \
 
 class half2_t {
-public:
+ public:
 #if MSHADOW_CUDA_HALF2
   half2 half2_;
 #else

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -55,6 +55,15 @@ public:
   }
 #endif
 
+  MSHADOW_HALF2_INLINE explicit half2_t(int a) {
+#if MSHADOW_CUDA_HALF2
+    half2_ = __half2half2(__int2half_rz(a));
+#else
+    half_t2[0] = (half_t)a;
+    half_t2[1] = (half_t)a;
+#endif
+  }
+
   MSHADOW_HALF2_INLINE half2_t operator+() {
     return *this;
   }

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -11,14 +11,6 @@
 #if (defined(__CUDACC__) && __CUDA_ARCH__ >= 530 && MSHADOW_USE_CUDA && CUDA_VERSION >= 7050)
   #define MSHADOW_CUDA_HALF2 1
   #include <cuda_fp16.h>
-  // #if defined(__CUDA_ARCH__)
-  //   /*! \brief __half2float_warp */
-  //   __host__ __device__ float __half2float_warp(const volatile __half& h) { /* NOLINT(*) */
-  //     __half val;
-  //     val.x = h.x;
-  //     return __half2float(val);
-  //   }
-  // #endif
 #else
   #define MSHADOW_CUDA_HALF2 0
 #endif
@@ -135,5 +127,5 @@ MSHADOW_HALF2_INLINE bool operator==(half2_t a, half2_t b) {
 
 }  // namespace half
 }  // namespace mshadow
-#endif  // MSHADOW_HALF_H_
+#endif  // MSHADOW_HALF2_H_
 

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -107,7 +107,7 @@ MSHADOW_HALF2_INLINE half2_t operator*(half2_t a, half2_t b) {
   return half2_t(a.half_t2[0] * b.half_t2[0], a.half_t2[1] * b.half_t2[1]);
 #endif
 }
-/*! \brief overloaded * operator for half2_t */
+/*! \brief overloaded / operator for half2_t */
 MSHADOW_HALF2_INLINE half2_t operator/(half2_t a, half2_t b) {
 #if MSHADOW_CUDA_HALF2
   return half2_t(h2div(a.half2_, b.half2_));
@@ -115,7 +115,7 @@ MSHADOW_HALF2_INLINE half2_t operator/(half2_t a, half2_t b) {
   return half2_t(a.half_t2[0] / b.half_t2[0], a.half_t2[1] / b.half_t2[1]);
 #endif
 }
-/*! \brief overloaded * operator for half2_t */
+/*! \brief overloaded == operator for half2_t */
 MSHADOW_HALF2_INLINE bool operator==(half2_t a, half2_t b) {
 #if MSHADOW_CUDA_HALF2
   return __hbeq2(a.half2_, b.half2_);

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -1,0 +1,130 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file half2.h
+ * \brief definition of vector float16, half2 type.
+ *
+ * \author Antti-Pekka Hynninen
+ */
+#ifndef MSHADOW_HALF2_H_
+#define MSHADOW_HALF2_H_
+
+#if (defined(__CUDACC__) && __CUDA_ARCH__ >= 530 && MSHADOW_USE_CUDA && CUDA_VERSION >= 7050)
+  #define MSHADOW_CUDA_HALF2 1
+  #include <cuda_fp16.h>
+  // #if defined(__CUDA_ARCH__)
+  //   /*! \brief __half2float_warp */
+  //   __host__ __device__ float __half2float_warp(const volatile __half& h) { /* NOLINT(*) */
+  //     __half val;
+  //     val.x = h.x;
+  //     return __half2float(val);
+  //   }
+  // #endif
+#else
+  #define MSHADOW_CUDA_HALF2 0
+#endif
+
+/*! \brief namespace for mshadow */
+namespace mshadow {
+/* \brief name space for host/device portable half-precision floats */
+namespace half {
+
+#define MSHADOW_HALF2_INLINE MSHADOW_FORCE_INLINE __device__
+
+#define MSHADOW_HALF2_ASSIGNOP(AOP, OP)                                   \
+  template<typename T>                                                    \
+  MSHADOW_XINLINE half2_t operator AOP (const T& a) {                     \
+    return *this = half2_t(*this OP a);  /* NOLINT(*)*/                   \
+  }                                                                       \
+
+class half2_t {
+public:
+#if MSHADOW_CUDA_HALF2
+  half2 half2_;
+#else
+  half_t half_t2[2];
+#endif
+
+  MSHADOW_HALF2_INLINE half2_t() {}
+
+#if MSHADOW_CUDA_HALF2
+  MSHADOW_HALF2_INLINE explicit half2_t(half2 a) : half2_(a) {}
+#else
+  MSHADOW_HALF2_INLINE explicit half2_t(half_t a, half_t b) {
+    half_t2[0] = a;
+    half_t2[1] = b;
+  }
+#endif
+
+  MSHADOW_HALF2_INLINE half2_t operator+() {
+    return *this;
+  }
+
+  MSHADOW_HALF2_INLINE half2_t operator-() {
+#if MSHADOW_CUDA_HALF2
+    return half2_t(__hneg2(half2_));
+#else
+    return half2_t(-half_t2[0], -half_t2[1]);
+#endif
+  }
+
+  MSHADOW_HALF2_INLINE half2_t operator=(const half2_t& a) {
+#if MSHADOW_CUDA_HALF2
+    half2_ = a.half2_;
+#else
+    half_t2[0] = a.half_t2[0];
+    half_t2[1] = a.half_t2[1];
+#endif
+    return a;
+  }
+
+  MSHADOW_HALF2_ASSIGNOP(+=, +)
+  MSHADOW_HALF2_ASSIGNOP(-=, -)
+  MSHADOW_HALF2_ASSIGNOP(*=, *)
+  MSHADOW_HALF2_ASSIGNOP(/=, /)
+};
+
+/*! \brief overloaded + operator for half2_t */
+MSHADOW_HALF2_INLINE half2_t operator+(half2_t a, half2_t b) {
+#if MSHADOW_CUDA_HALF2
+  return half2_t(__hadd2(a.half2_, b.half2_));
+#else
+  return half2_t(a.half_t2[0] + b.half_t2[0], a.half_t2[1] + b.half_t2[1]);
+#endif
+}
+/*! \brief overloaded - operator for half2_t */
+MSHADOW_HALF2_INLINE half2_t operator-(half2_t a, half2_t b) {
+#if MSHADOW_CUDA_HALF2
+  return half2_t(__hsub2(a.half2_, b.half2_));
+#else
+  return half2_t(a.half_t2[0] - b.half_t2[0], a.half_t2[1] - b.half_t2[1]);
+#endif
+}
+/*! \brief overloaded * operator for half2_t */
+MSHADOW_HALF2_INLINE half2_t operator*(half2_t a, half2_t b) {
+#if MSHADOW_CUDA_HALF2
+  return half2_t(__hmul2(a.half2_, b.half2_));
+#else
+  return half2_t(a.half_t2[0] * b.half_t2[0], a.half_t2[1] * b.half_t2[1]);
+#endif
+}
+/*! \brief overloaded * operator for half2_t */
+MSHADOW_HALF2_INLINE half2_t operator/(half2_t a, half2_t b) {
+#if MSHADOW_CUDA_HALF2
+  return half2_t(h2div(a.half2_, b.half2_));
+#else
+  return half2_t(a.half_t2[0] / b.half_t2[0], a.half_t2[1] / b.half_t2[1]);
+#endif
+}
+/*! \brief overloaded * operator for half2_t */
+MSHADOW_HALF2_INLINE bool operator==(half2_t a, half2_t b) {
+#if MSHADOW_CUDA_HALF2
+  return __hbeq2(a.half2_, b.half2_);
+#else
+  return (a.half_t2[0] == b.half_t2[0] && a.half_t2[1] == b.half_t2[1]);
+#endif
+}
+
+}  // namespace half
+}  // namespace mshadow
+#endif  // MSHADOW_HALF_H_
+


### PR DESCRIPTION
Implements half2 type that is needed for efficient half precision computations. MSHADOW_TYPE_SWITCH_WITH_HALF2 converts float16 input into half2