### PR TITLE
Revert 19fae920 (#227)

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -38,7 +38,7 @@ const int kBaseThreadBits = 8;
 /*! \brief suggested thread number for mapping kernel */
 const int kBaseThreadNum  = 1 << kBaseThreadBits;
 /*! \brief maximum value of grid */
-const int kMaxGridNum = 2147483647;
+const int kMaxGridNum = 65535;
 /*! \brief maximum value of grid within each dimension */
 const int kMaxGridDim = 65535;
 /*! \brief suggested grid number for mapping kernel */


### PR DESCRIPTION
There are 6 tests in mxnet test_operator_gpu that would fail when #227 is applied. The operators that have problems are ```one_hot, where, new_softmax, log_softmax, pick, custom_op```. I have tested that by reverting the ```kMaxGridNum``` value the errors are fixed.
The first 5 operators failed the tests with errors that look like:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python2.7/site-packages/nose/util.py", line 620, in newfunc
    return func(*arg, **kw)
  File "/home/ec2-user/mxnet/tests/python/gpu/../unittest/test_operator.py", line 3038, in test_custom_op
    check_numeric_gradient(op, [x])
  File "/usr/local/lib/python2.7/site-packages/mxnet/test_utils.py", line 450, in check_numeric_gradient
    executor.forward(is_train=True)
  File "/usr/local/lib/python2.7/site-packages/mxnet/executor.py", line 124, in forward
    ctypes.c_int(int(is_train))))
  File "/usr/local/lib/python2.7/site-packages/mxnet/base.py", line 84, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
MXNetError: [07:03:50] src/operator/custom/custom.cc:77: Check failed: reinterpret_cast<CustomOpFBFunc>(op_info_->callbacks[kCustomOpForward])( ptrs.size(), ptrs.data(), tags.data(), reqs.data(), static_cast<int>(ctx.is_train), op_info_->contexts[kCustomOpForward])
```
The problem in ```custom_op``` looks different:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python2.7/site-packages/nose/util.py", line 620, in newfunc
    return func(*arg, **kw)
  File "/home/ec2-user/mxnet/tests/python/gpu/../unittest/test_operator.py", line 3038, in test_custom_op
    check_numeric_gradient(op, [x])
  File "/usr/local/lib/python2.7/site-packages/mxnet/test_utils.py", line 450, in check_numeric_gradient
    executor.forward(is_train=True)
  File "/usr/local/lib/python2.7/site-packages/mxnet/executor.py", line 124, in forward
    ctypes.c_int(int(is_train))))
  File "/usr/local/lib/python2.7/site-packages/mxnet/base.py", line 84, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
MXNetError: [07:03:50] src/operator/custom/custom.cc:77: Check failed: reinterpret_cast<CustomOpFBFunc>(op_info_->callbacks[kCustomOpForward])( ptrs.size(), ptrs.data(), tags.data(), reqs.data(), static_cast<int>(ctx.is_train), op_info_->contexts[kCustomOpForward])
```