### PR TITLE
Add int type switch

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -890,6 +890,30 @@ struct minimum {
     LOG(FATAL) << "Unknown layout enum " << layout; \
   }
 
+#define MSHADOW_INT_TYPE_SWITCH(type, DType, ...)   \
+  switch (type) {                                   \
+  case mshadow::kUint8:                             \
+    {                                               \
+      typedef uint8_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt8:                              \
+    {                                               \
+      typedef int8_t DType;                         \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  case mshadow::kInt32:                             \
+    {                                               \
+      typedef int32_t DType;                        \
+      {__VA_ARGS__}                                 \
+    }                                               \
+    break;                                          \
+  default:                                          \
+    LOG(FATAL) << "Unknown type enum " << type;     \
+  }
+
 /*! \brief get data type size from type enum */
 inline size_t mshadow_sizeof(int type) {
   int size = 0;


### PR DESCRIPTION
We need this INT_TYPE_SWITCH for switching index types in sparse tensor development, where aux_data is index and can be set by users.