### PR TITLE
Fix for MXNet LRN operator due to bug in channel_pool

### DIFF
--- a/mshadow/extension/channel_pool.h
+++ b/mshadow/extension/channel_pool.h
@@ -90,7 +90,7 @@ struct Plan<ChannelPoolingExp<Reducer, SrcExp, DType, srcdim>, DType> {
     const index_t n = i / channel_;
     const index_t x = j;
     const index_t cstart = c * stride_ < pad_ ? 0  : c * stride_ - pad_;
-    const index_t cend   = min(cstart + hnsize_, channel_);
+    const index_t cend   = min(c * stride_ - pad_ + hnsize_, channel_);
     DType res; Reducer::SetInitValue(res);
     for (index_t cc = cstart; cc < cend; ++cc) {
       Reducer::Reduce(res, src_.Eval((n * src_channel_ + cc) * height_ + y, x));


### PR DESCRIPTION
There was an indexing bug in the underlying c++ implementation of the **channel_pool** class which is used to perform channel-wise pooling.

I will give an example to explain the problem.
Suppose we have an array with 10 elements, indexed 0 to 9
And we want to perform sum pooling with window size 5.

So the 1st output item should look at the first index, 0, and take a 5-window around it, namely indexes [-2,2] which is then fixed to [0,2] since negative indexes are invalid.

The 2nd output item should look at the indexes [-1,3] which is fixed to [0,3] since negative indexes are invalid.
The 3rd output item should look at the indexes [0,4]
The 4th output item should look at the indexes [1,5]
The 5th output item should look at the indexes [2,6]
The 6th output item should look at the indexes [3,7]
The 7th output item should look at the indexes [4,8]
The 8th output item should look at the indexes [5,9]
The 9th output item should look at the indexes [6,10] which is fixed to [6,9] since 9 is the last element in the input array.
The 10th output item should look at the indexes [7,10] which is fixed to [0,3] since 9 is the last element in the input array.

Before the fix, the code used to calculate the starting index (named `cstart`), and corrected it to be at least 0.
Then he would assume that the ending index (named `cend`) is calculated by `cend = cstart + 5`, and corrected the upper bound.

The problem is that the ending index calculation should NOT take into account the correction of `cstart` to decide on the upper bound.
In our example, the indexes for the 1st item were fixed from [-2,2] to [0,4] instead of being [0,2]
In a similar way the 2nd output item got corrupted.

This affects output values on the starting edge, i.e. first channels.
But the accumulative result can reduce the over-whole performance of the system.

Like many indexing bugs, once you understand the problem, the solution is a single line fix. 