### PR TITLE
Fix SetInitValue overflow when DType is int

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -620,6 +620,11 @@ template<>
 MSHADOW_XINLINE double MaxValue<double>(void) {
   return DBL_MAX;
 }
+/*! \brief maximum value of half */
+template<>
+MSHADOW_XINLINE half::half_t MaxValue<half::half_t>(void) {
+  return MSHADOW_HALF_MAX;
+}
 /*! \brief maximum value of uint8_t */
 template<>
 MSHADOW_XINLINE uint8_t MaxValue<uint8_t>(void) {
@@ -718,7 +723,7 @@ struct minimum {
    */
   template<typename DType>
   MSHADOW_XINLINE static void SetInitValue(DType &initv) { // NOLINT(*)
-    initv = -limits::MinValue<DType>();
+    initv = limits::MaxValue<DType>();
   }
 };
 }  // namespace red

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -268,6 +268,7 @@ MSHADOW_HALF_OPERATOR(bool, >=)
 MSHADOW_HALF_OPERATOR(bool, <=)
 
 #define MSHADOW_HALF_MIN mshadow::half::half_t::Binary(0x0400);
+#define MSHADOW_HALF_MAX mshadow::half::half_t::Binary(0x7AFF);
 }  // namespace half
 }  // namespace mshadow
 #endif  // MSHADOW_HALF_H_


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Half-precision_floating-point_format

`0 11110 1111111111 = 65504  (max half precision)`
