### PR TITLE
fix ambiguous template deduction for SortKey<half_t, half_t>

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -708,6 +708,12 @@ inline void SortByKey(Tensor<gpu, 1, DType> keys, Tensor<gpu, 1, mshadow::half::
   bool is_ascend) {
   LOG(FATAL) << "SortByKey for half_t is not implemented!";
 }
+
+// break ambiguous template deduction for <half_t, half_t>
+inline void SortByKey(Tensor<gpu, 1, mshadow::half::half_t> keys, Tensor<gpu, 1, mshadow::half::half_t> values,
+  bool is_ascend) {
+  LOG(FATAL) << "SortByKey for half_t is not implemented!";
+}
 }  // namespace cuda
 }  // namespace mshadow
 #endif  // MSHADOW_CUDA_TENSOR_GPU_INL_CUH_

--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -712,7 +712,8 @@ inline void SortByKey(Tensor<gpu, 1, DType> keys, Tensor<gpu, 1, mshadow::half::
 }
 
 // break ambiguous template deduction for <half_t, half_t>
-inline void SortByKey(Tensor<gpu, 1, mshadow::half::half_t> keys, Tensor<gpu, 1, mshadow::half::half_t> values,
+inline void SortByKey(Tensor<gpu, 1, mshadow::half::half_t> keys,
+  Tensor<gpu, 1, mshadow::half::half_t> values,
   bool is_ascend) {
   LOG(FATAL) << "SortByKey for half_t is not implemented!";
 }


### PR DESCRIPTION
```
error: more than one instance of overloaded function "mshadow::cuda::SortByKey" matches the argument list:
            function template "void mshadow::cuda::SortByKey(mshadow::Tensor<mshadow::gpu, 1, mshadow::half::half_t>, mshadow::Tensor<mshadow::gpu, 1, DType>, __nv_bool)"
            function template "void mshadow::cuda::SortByKey(mshadow::Tensor<mshadow::gpu, 1, DType>, mshadow::Tensor<mshadow::gpu, 1, mshadow::half::half_t>, __nv_bool)"
            argument types are: (mshadow::Tensor<mshadow::gpu, 1, mshadow::half::half_t>, mshadow::Tensor<mshadow::gpu, 1, mshadow::half::half_t>, __nv_bool)
```
fix SortKey<half_t, half_t> matching to two templates