### PR TITLE
int64 for aux_data idx type switch

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -931,26 +931,12 @@ struct minimum {
     LOG(FATAL) << "Unknown layout enum " << layout; \
   }
 
-#define MSHADOW_INT_TYPE_SWITCH(type, DType, ...)   \
+/*!
+ * \brief Only supports int64 index type for aux_data
+ * in NDArray class fow now.
+ */
+#define MSHADOW_IDX_TYPE_SWITCH(type, DType, ...)   \
   switch (type) {                                   \
-  case mshadow::kUint8:                             \
-    {                                               \
-      typedef uint8_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt8:                              \
-    {                                               \
-      typedef int8_t DType;                         \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
-  case mshadow::kInt32:                             \
-    {                                               \
-      typedef int32_t DType;                        \
-      {__VA_ARGS__}                                 \
-    }                                               \
-    break;                                          \
   case mshadow::kInt64:                             \
     {                                               \
       typedef int64_t DType;                        \


### PR DESCRIPTION
As discussed last week, we are going to only support int64 index type for aux_data in the class NDArray.