### PR TITLE
added single/double floating-point type switch

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -818,23 +818,23 @@ struct minimum {
     LOG(FATAL) << "Unknown type enum " << type;           \
   }
 
-#define MSHADOW_SINGLE_DOUBLE_TYPE_SWITCH(type, DType, ...)  \
-  switch (type) {                                            \
-  case mshadow::kFloat32:                                    \
-    {                                                        \
-      typedef float DType;                                   \
-      {__VA_ARGS__}                                          \
-    }                                                        \
-    break;                                                   \
-  case mshadow::kFloat64:                                    \
-    {                                                        \
-      typedef double DType;                                  \
-      {__VA_ARGS__}                                          \
-    }                                                        \
-    break;                                                   \
-  default:                                                   \
-    LOG(FATAL) << "This operation only supports "            \
-                  "32- and 64-bit floating point";           \
+#define MSHADOW_SGL_DBL_TYPE_SWITCH(type, DType, ...)  \
+  switch (type) {                                      \
+  case mshadow::kFloat32:                              \
+    {                                                  \
+      typedef float DType;                             \
+      {__VA_ARGS__}                                    \
+    }                                                  \
+    break;                                             \
+  case mshadow::kFloat64:                              \
+    {                                                  \
+      typedef double DType;                            \
+      {__VA_ARGS__}                                    \
+    }                                                  \
+    break;                                             \
+  default:                                             \
+    LOG(FATAL) << "This operation only supports "      \
+                  "32- and 64-bit floating point";     \
   }
 
 #define MSHADOW_REAL_TYPE_SWITCH(type, DType, ...)  \

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -818,6 +818,25 @@ struct minimum {
     LOG(FATAL) << "Unknown type enum " << type;           \
   }
 
+#define MSHADOW_SINGLE_DOUBLE_TYPE_SWITCH(type, DType, ...)  \
+  switch (type) {                                            \
+  case mshadow::kFloat32:                                    \
+    {                                                        \
+      typedef float DType;                                   \
+      {__VA_ARGS__}                                          \
+    }                                                        \
+    break;                                                   \
+  case mshadow::kFloat64:                                    \
+    {                                                        \
+      typedef double DType;                                  \
+      {__VA_ARGS__}                                          \
+    }                                                        \
+    break;                                                   \
+  default:                                                   \
+    LOG(FATAL) << "This operation only supports "            \
+                  "32- and 64-bit floating point";           \
+  }
+
 #define MSHADOW_REAL_TYPE_SWITCH(type, DType, ...)  \
   switch (type) {                                   \
   case mshadow::kFloat32:                           \


### PR DESCRIPTION
New optimized MXNet GPU kernels for the dot operator will use atomic operations that only allow 32- and 64-bit, not half precision FP.
@piiswrong @madjam @reminisce @bhavinthaker @eric-haibin-lin 