### PR TITLE
Remove include tensor_tblob.h

### DIFF
--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -649,7 +649,7 @@ template<typename Device>
 inline Stream<Device> *NewStream(bool create_blas_handle,
                                  bool create_dnn_handle,
                                  int dev_id = -1);
-/*! \brief default behavior: create cublas handle 
+/*! \brief default behavior: create cublas handle
  *  \param dev_id device id
  *  \return a pointer to the created stream
  */
@@ -1055,7 +1055,6 @@ inline void BatchGEMM(Tensor<Device, 3, DType> dst,
 #include "./tensor_gpu-inl.h"
 #include "./io.h"
 #include "./tensor_container.h"
-#include "./tensor_blob.h"
 #include "./random.h"
 // add definition of scalar related operators
 #ifdef MSHADOW_SCALAR_


### PR DESCRIPTION
This line will bring some conflict with nnvm::TShape in specific include order.

We should remove mshadow::TShape and mshadow::TBlob in the future.