### PR TITLE
Incorporating cusolver in order to support linear algebra operators i…

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -26,7 +26,7 @@ endif
 ifeq ($(USE_CUDA), 0)
 	MSHADOW_CFLAGS += -DMSHADOW_USE_CUDA=0
 else
-	MSHADOW_LDFLAGS += -lcudart -lcublas -lcurand
+	MSHADOW_LDFLAGS += -lcudart -lcublas -lcurand -lcusolver
 endif
 ifneq ($(USE_CUDA_PATH), NONE)
 	MSHADOW_CFLAGS += -I$(USE_CUDA_PATH)/include

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -102,6 +102,13 @@ typedef unsigned __int64 uint64_t;
 #endif
 
 /*!
+ * \brief use CUSOLVER support
+ */
+#ifndef MSHADOW_USE_CUSOLVER
+  #define MSHADOW_USE_CUSOLVER MSHADOW_USE_CUDA
+#endif
+
+/*!
  * \brief seems CUDAARCH is deprecated in future NVCC
  * set this to 1 if you want to use CUDA version smaller than 2.0
  */
@@ -150,6 +157,10 @@ extern "C" {
 
 #if MSHADOW_USE_CUDNN == 1
   #include <cudnn.h>
+#endif
+
+#if MSHADOW_USE_CUSOLVER == 1
+  #include <cusolverDn.h>
 #endif
 
 #if MSHADOW_USE_NVML

--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -26,12 +26,18 @@ struct Stream<gpu> {
   cudaStream_t stream_;
   /*! \brief cublas handle */
   cublasHandle_t blas_handle_;
+  /*! \brief cusolver handle */
+  #if MSHADOW_USE_CUSOLVER == 1
+  cusolverDnHandle_t solver_handle_;
+  #endif
   /*! \brief cudnn handle */
   #if MSHADOW_USE_CUDNN == 1
   cudnnHandle_t dnn_handle_;
   #endif
   /*! \brief cublas handle ownership */
   HandleState blas_handle_ownership_;
+  /*! \brief cusolver handle ownership */
+  HandleState solver_handle_ownership_;
   /*! \brief cudnn handle ownership */
   HandleState dnn_handle_ownership_;
   /*! \brief cudaDeviceProp */
@@ -46,6 +52,7 @@ struct Stream<gpu> {
       , dnn_handle_(0)
 #endif
       , blas_handle_ownership_(NoHandle)
+      , solver_handle_ownership_(NoHandle)
       , dnn_handle_ownership_(NoHandle) {}
   /*!
    * \brief wait for all the computation associated
@@ -93,7 +100,7 @@ struct Stream<gpu> {
     }
   }
   /*! \brief Destory cublas handle if own it */
-  inline void DestoryBlasHandle() {
+  inline void DestroyBlasHandle() {
     if (blas_handle_ownership_ == OwnHandle) {
       cublasStatus_t err = cublasDestroy(blas_handle_);
       blas_handle_ownership_ = NoHandle;
@@ -102,10 +109,38 @@ struct Stream<gpu> {
   }
   /*! \brief Destory original blas handle and create a new one */
   inline void CreateBlasHandle() {
-    this->DestoryBlasHandle();
+    this->DestroyBlasHandle();
     cublasStatus_t err = cublasCreate(&blas_handle_);
     blas_handle_ownership_ = OwnHandle;
     CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Create cublas handle failed";
+  }
+#if MSHADOW_USE_CUSOLVER == 1
+  inline static cusolverDnHandle_t GetSolverHandle(Stream<gpu> *stream) {
+    if (stream == NULL) {
+      return 0;
+    } else {
+      CHECK_NE(stream->solver_handle_ownership_, NoHandle) << "No handle exist in source stream";
+      return stream->solver_handle_;
+    }
+  }
+#endif
+  inline void DestroySolverHandle() {
+#if MSHADOW_USE_CUSOLVER == 1
+    if (solver_handle_ownership_ == OwnHandle) {
+      cusolverStatus_t err = cusolverDnDestroy(solver_handle_);
+      CHECK_EQ(err, CUSOLVER_STATUS_SUCCESS) << "Destory cusolver handle failed";
+    }
+#endif
+  }
+  inline void CreateSolverHandle() {
+#if MSHADOW_USE_CUSOLVER == 1
+    this->DestroySolverHandle();
+    cusolverStatus_t err = cusolverDnCreate(&solver_handle_);
+    CHECK_EQ(err, CUSOLVER_STATUS_SUCCESS) << "Create cusolver handle failed";
+    err = cusolverDnSetStream(solver_handle_, stream_);
+    CHECK_EQ(err, CUSOLVER_STATUS_SUCCESS) << "Setting cusolver stream failed";
+    this->solver_handle_ownership_ = OwnHandle;
+#endif
   }
 // #if MSHADOW_USE_CUDNN && defined(__CUDACC__)
 #if MSHADOW_USE_CUDNN == 1
@@ -145,7 +180,8 @@ template<>
 inline void DeleteStream<gpu>(Stream<gpu> *stream) {
   if (stream) {
     MSHADOW_CUDA_CALL(cudaStreamDestroy(stream->stream_));
-    stream->DestoryBlasHandle();
+    stream->DestroyBlasHandle();
+    stream->DestroySolverHandle();
     stream->DestroyDnnHandle();
     delete stream;
   }
@@ -160,6 +196,7 @@ inline Stream<gpu> *NewStream<gpu>(bool create_blas_handle,
   MSHADOW_CUDA_CALL(cudaStreamCreate(&st->stream_));
   if (create_blas_handle) {
     st->CreateBlasHandle();
+    st->CreateSolverHandle();
   }
   if (create_dnn_handle) {
     st->CreateDnnHandle();

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -639,7 +639,7 @@ template<typename Device>
 inline void SetDevice(int devid);
 /*!
  * \brief create a new stream from system
- * \param create_blas_handle whether create blas handle in stream
+ * \param create_blas_handle whether create blas & cusolver handle in stream
  * \param create_dnn_handle whether create cudnn handle in stream
  * \param dev_id device id
  * \return a pointer to the created stream

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ export CC  = gcc
 export CXX = g++
 export NVCC =nvcc
 export CFLAGS = -Wall -O3 -g -msse3 -Wno-unknown-pragmas -funroll-loops -I../
-export LDFLAGS= -g -lm -lcublas -lcudart
+export LDFLAGS= -g -lm -lcublas -lcudart -lcusolver
 export NVCCFLAGS = -O3 --use_fast_math -ccbin $(CXX)
 
 # specify tensor path


### PR DESCRIPTION
Incorporating cusolver into mshadow as a prerequisite to support lapack like linear algebra functions on gpu. This is a prerequisite to the main pull request that follows on mxnet repo. cusolver is available on cuda 7.5 and 8.0 so on all versions that MXNet oficially supports. 

Also added one more type switch that makes it easier for the code of the linear algebra operators (as they only work on 32/64-bit floating point types and there is no use in making them work on any other precision).  