### PR TITLE
Resolve gcc7 compile warnings

### DIFF
--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -299,6 +299,7 @@ inline Shape<4> ConvertLayout(const Shape<4>& src, int src_layout, int dst_layou
     break;
   default:
     LOG(FATAL) << "Invalid layout for 4d shape " << src_layout;
+    dst = src;  // fixes compiler warning
   }
   Shape<4> dst2;
   switch (dst_layout) {
@@ -312,6 +313,7 @@ inline Shape<4> ConvertLayout(const Shape<4>& src, int src_layout, int dst_layou
     break;
   default:
     LOG(FATAL) << "Invalid layout for 4d shape " << src_layout;
+    dst2 = src;  // fixes compiler warning
   }
   return dst2;
 }

--- a/mshadow/tensor_cpu-inl.h
+++ b/mshadow/tensor_cpu-inl.h
@@ -309,7 +309,7 @@ inline void SoftmaxGrad(Tensor<cpu, 2, DType> dst,
 #pragma omp parallel for
   for (openmp_index_t y = 0; y < dst.size(0); ++y) {
     const int k = static_cast<int>(label[y]);
-    for (int x = 0; x < dst.size(1); ++x) {
+    for (int x = 0; x < static_cast<int>(dst.size(1)); ++x) {
       if (static_cast<int>(ignore_label) == k) {
         dst[y][x] = 0.0f;
       } else {
@@ -331,7 +331,7 @@ inline void SoftmaxGrad(Tensor<cpu, 3, DType> dst,
   for (openmp_index_t n = 0; n < dst.size(2); ++n) {
     for (index_t y = 0; y < dst.size(0); ++y) {
       const int k = static_cast<int>(label[y][n]);
-      for (int x = 0; x < dst.size(1); ++x) {
+      for (int x = 0; x < static_cast<int>(dst.size(1)); ++x) {
         if (x == k) {
           dst[y][k][n] = src[y][k][n] - 1.0f;
         } else {
@@ -352,11 +352,11 @@ inline void SoftmaxGrad(Tensor<cpu, 3, DType> dst,
     for (index_t y = 0; y < dst.size(0); ++y) {
       const int k = static_cast<int>(label[y][n]);
       if (k == static_cast<int>(ignore_label)) {
-        for (int x = 0; x < dst.size(1); ++x) {
+        for (int x = 0; x < static_cast<int>(dst.size(1)); ++x) {
           dst[y][x][n] = DType(0.0f);
         }
       } else {
-        for (int x = 0; x < dst.size(1); ++x) {
+        for (int x = 0; x < static_cast<int>(dst.size(1)); ++x) {
           if (x == k) {
             dst[y][k][n] = src[y][k][n] - 1.0f;
           } else {


### PR DESCRIPTION
This PR fixes these two types of warnings raised by gcc7
1. Sign compare in tensor_cpu-inl.h
2. Variables may be uninitialized in tensor.h . The parts of code that confuse gcc7 will only be reached in the case of failure, so it won't really affect in runtime. To fix compile warning, we initialize the variables as shown. This change was discussed with @cjolivier01 . I compiled it and verified that there is no warning anymore. 

Please let me know if you have any suggestions.

---
Note that the latest release currently is 7.1.0, which has a bug regarding strict-aliasing (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80593). This is the reason for about 540 warnings which show up when mxnet is compiled with gcc7.1. 
I verified that the bug is indeed what affects us by compiling gcc from source using the current commit on ```gcc-7-branch``` branch. This latest commit has the timestamp of 2017-08-02 16:27:42. 

Once this is released and with the changes in this PR, we won't have any warning with gcc7 compiler.
