### PR TITLE
Fill Index enable larger size and remove performance bottleneck

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -666,7 +666,7 @@ inline void IndexFill(Tensor<gpu, 2, DType> dst,
   int grid_dim_x = (src.size(0) * src.size(1) + block_size - 1) / block_size;
   int grid_dim_y = 1;
   while (grid_dim_x > kMaxGridDim) {
-    grid_dim_x = (grid_dim_x+1)/2;
+    grid_dim_x = (grid_dim_x + 1) / 2;
     grid_dim_y *= 2;
   }
   dim3 dimBlock(block_dim_x, block_dim_y);

--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -637,14 +637,17 @@ inline void AddTakeGradLargeBatch(Tensor<gpu, 2, DType> dst,
 
 template<int warp_bits, typename DType, typename DstPlan, typename IndexPlan, typename SrcPlan>
 __global__ void IndexFillKernel(DstPlan dst,
-                                IndexPlan index, SrcPlan src,
-                                index_t ymax, int xmax) {
-  int src_idx = blockIdx.x * blockDim.y + threadIdx.y;
-  if (src_idx < ymax) {
-    int dst_idx = static_cast<int>(index.Eval(0, src_idx));
-    for (int i = threadIdx.x; i < xmax; i += blockDim.x) {
-      dst.REval(dst_idx, i) = src.Eval(src_idx, i);
-    }
+                                const IndexPlan index,
+                                const SrcPlan src,
+                                const int ymax,
+                                const int xmax) {
+  int bid = blockIdx.y * blockDim.x + blockIdx.x;
+  int tid = bid * blockDim.x * blockDim.y + threadIdx.y * blockDim.x + threadIdx.x;
+  if (tid < ymax * xmax) {
+    int i = tid / xmax;
+    int j = tid % xmax;
+    int k = static_cast<int>(index.Eval(0, i));
+    dst.REval(k, j) = src.Eval(i, j);
   }
 }
 
@@ -659,9 +662,15 @@ inline void IndexFill(Tensor<gpu, 2, DType> dst,
   CHECK_EQ(index.size(0), src.size(0)) << "IndexFill: shape mismatch";
   const int block_dim_x = 1 << kMemUnitBits;
   const int block_dim_y = 1 << kMemUnitBits;
-  const int grid_dim_x = (src.size(0) + block_dim_y - 1) / block_dim_y;
+  const int block_size = block_dim_x * block_dim_y;
+  int grid_dim_x = (src.size(0) * src.size(1) + block_size - 1) / block_size;
+  int grid_dim_y = 1;
+  while (grid_dim_x > kMaxGridDim) {
+    grid_dim_x = (grid_dim_x+1)/2;
+    grid_dim_y *= 2;
+  }
   dim3 dimBlock(block_dim_x, block_dim_y);
-  dim3 dimGrid(grid_dim_x);
+  dim3 dimGrid(grid_dim_x, grid_dim_y);
   CheckLaunchParam(dimGrid, dimBlock, "IndexFill");
   cudaStream_t stream = Stream<gpu>::GetStream(dst.stream_);
 


### PR DESCRIPTION
@piiswrong @eric-haibin-lin @reminisce @bhavinthaker @Guneet-Dhillon
Some changes in response to https://stackoverflow.com/questions/45448677/using-topk-to-prune-inputs-in-mxnet/45476944#45476944
1) Enabled larger sizes for Fill Index function:
Previously, limit of 65535*32. Now, the limit is essentially the 32bit integer limit.
2) Improved performance of Fill Index Kernel
Previously, only 1 in 32 threads did work in the Fill Index kernel while the other 31 threads remained idle. Now, each thread has the same amount of work which increases performance significantly.