### PR TITLE
add support for mac mkl

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -74,7 +74,7 @@ endif
 
 ifeq ($(USE_MKLML), 1)
 	MSHADOW_CFLAGS += -I$(MKLROOT)/include
-	MSHADOW_LDFLAGS += -Wl,--as-needed -lmklml_intel -lmklml_gnu -liomp5 -L$(MKLROOT)/lib/
+	MSHADOW_LDFLAGS += -Wl,--as-needed -lmklml_intel -lmklml_gnu -lmklml -liomp5 -L$(MKLROOT)/lib/
 endif
 
 ifeq ($(USE_BLAS), openblas)


### PR DESCRIPTION
mkl 2017 on mac has the name libmklml.dylib, so adding the linker flag for the support.