### PR TITLE
Fused softmax smoothing

### DIFF
--- a/mshadow/cuda/tensor_gpu-inl.cuh
+++ b/mshadow/cuda/tensor_gpu-inl.cuh
@@ -261,6 +261,7 @@ __global__ void SmoothSoftmaxGradKernel(DstPlan dst, SrcPlan1 src, SrcPlan2 labe
   const unsigned x_size = 1 << x_bits;
   const int y = blockIdx.x;
   const int k = static_cast<int>(label.Eval(0, y));
+  // xmax is the number of classes in our distribution
   const float smooth_grad = (alpha / (xmax - 1));
 
   // calculate normalizer, with writeback
@@ -306,6 +307,7 @@ __global__ void SmoothSoftmaxGradKernel(DstPlan dst, SrcPlan1 src, SrcPlan2 labe
   const unsigned x_size = 1 << x_bits;
   const int y = blockIdx.x;
   const int k = static_cast<int>(label.Eval(0, y));
+  // xmax is the number of classes in our distribution
   const float smooth_grad = (alpha / (xmax - 1));
 
   // calculate normalizer, with writeback

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -806,7 +806,7 @@ inline void SoftmaxGrad(Tensor<cpu, 2, DType> dst,
  * \param label label info
  */
 template<typename DType>
-inline void SoftmaxGrad(Tensor<gpu, 2, DType> dst,
+inline void SoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
                         const Tensor<gpu, 2, DType> &src,
                         const Tensor<gpu, 1, DType> &label);
 /*!

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -167,14 +167,22 @@ inline void Softmax(Tensor<gpu, 3, DType> dst,
 }
 
 template<typename DType>
-inline void SoftmaxGrad(Tensor<gpu, 2, DType> dst,
+inline void SoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
                         const Tensor<gpu, 2, DType> &src,
                         const Tensor<gpu, 1, DType> &label) {
   cuda::SoftmaxGrad(dst, src, label);
 }
 
 template<typename DType>
-inline void SoftmaxGrad(Tensor<gpu, 2, DType> dst,
+inline void SmoothSoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
+                              const Tensor<gpu, 2, DType> &src,
+                              const Tensor<gpu, 1, DType> &label,
+                              const float alpha) {
+  cuda::SmoothSoftmaxGrad(dst, src, label, alpha);
+}
+
+template<typename DType>
+inline void SoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
                         const Tensor<gpu, 2, DType> &src,
                         const Tensor<gpu, 1, DType> &label,
                         const DType &ignore_label) {
@@ -182,14 +190,23 @@ inline void SoftmaxGrad(Tensor<gpu, 2, DType> dst,
 }
 
 template<typename DType>
-inline void SoftmaxGrad(Tensor<gpu, 3, DType> dst,
+inline void SmoothSoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
+                              const Tensor<gpu, 2, DType> &src,
+                              const Tensor<gpu, 1, DType> &label,
+                              const DType &ignore_label,
+                              const float alpha){
+  cuda::SmoothSoftmaxGrad(dst, src, label, ignore_label, alpha);
+}
+
+template<typename DType>
+inline void SoftmaxGrad(const Tensor<gpu, 3, DType> &dst,
                         const Tensor<gpu, 3, DType> &src,
                         const Tensor<gpu, 2, DType> &label) {
   cuda::SoftmaxGrad(dst, src, label);
 }
 
 template<typename DType>
-inline void SoftmaxGrad(Tensor<gpu, 3, DType> dst,
+inline void SoftmaxGrad(const Tensor<gpu, 3, DType> &dst,
                         const Tensor<gpu, 3, DType> &src,
                         const Tensor<gpu, 2, DType> &label,
                         const DType &ignore_label) {

--- a/mshadow/tensor_gpu-inl.h
+++ b/mshadow/tensor_gpu-inl.h
@@ -194,7 +194,7 @@ inline void SmoothSoftmaxGrad(const Tensor<gpu, 2, DType> &dst,
                               const Tensor<gpu, 2, DType> &src,
                               const Tensor<gpu, 1, DType> &label,
                               const DType &ignore_label,
-                              const float alpha){
+                              const float alpha) {
   cuda::SmoothSoftmaxGrad(dst, src, label, ignore_label, alpha);
 }
 


### PR DESCRIPTION
As proposed by @fhieber in https://github.com/apache/incubator-mxnet/issues/6996 this PR helps reduce memory usage when using smoothing during softmax computation by doing the smoothing directly in the operator.  This modification was tested by @tdomhan and I and we found it reduced memory usage during training on a typical MT model by ~ 3GB.  

There is a corresponding change in mxnet that can make use of this operator, but this PR should be applied first.  This PR should be fully backwards compatible.