### PR TITLE
fix for random seed generation

### DIFF
--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -85,7 +85,7 @@ class Random<cpu, DType> {
    * \brief get a set of random integers
    */
   inline void GetRandInt(const Tensor<cpu, 1, unsigned>& dst) {
-    std::generate_n(dst.dptr_, dst.size(0), rnd_engine_);
+    std::generate_n(dst.dptr_, dst.size(0), [&](){ return rnd_engine_(); });
   }
 
   /*!


### PR DESCRIPTION
Fix for random integer (seed generation). The previous code did not advance the state of the random generator across calls of GetRandInt() as generate_n will receive the parameter by value (i.e. copy it) each time. 