### PR TITLE
[ARM] Change USE_SSE to SUPPORT_MSSE2 to it uses the autodetected presence …

### DIFF
--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -42,7 +42,7 @@ elseif(BLAS STREQUAL "apple")
   add_definitions(-DMSHADOW_USE_CBLAS=1)
 endif()
 
-if(USE_SSE)
+if(SUPPORT_MSSE2)
 	add_definitions(-DMSHADOW_USE_SSE=1)
 else()
 	add_definitions(-DMSHADOW_USE_SSE=0)


### PR DESCRIPTION
…of sse compiler flag from the parent project (see PR #8395)

Fixes compilation in ARM, no additional modifications in MXNet cmake needed.