### PR TITLE
Makes repeated setting of gpu rng seed produce repeatable sequences.

### DIFF
--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -398,7 +398,7 @@ class Random<gpu, DType> {
       CreateGenerator();
     // Now set the seed.
     curandStatus_t status;
-    status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<unsigned long long>(seed));
+    status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<uint64>(seed));
     CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
   }
   /*!

--- a/mshadow/random.h
+++ b/mshadow/random.h
@@ -398,7 +398,7 @@ class Random<gpu, DType> {
       CreateGenerator();
     // Now set the seed.
     curandStatus_t status;
-    status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<uint64>(seed));
+    status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<uint64_t>(seed));
     CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
   }
   /*!


### PR DESCRIPTION
This PR fixes the unintuitive behavior seen in mxnet...
```
mx.random.seed(1234)
<test1>
mx.random.seed(1234)
<test1>
```

...where the two instances of test1 see different sequences from mxnet's random number generator (but only on gpu's).  The problem is that the gpu generator state is composed of both a seed and an offset into the generated sequence.  Within mshadow's seed-setting routine Seed(), the seed is changed but the offset is currently left untouched.  This fix adapts Seed() to also set the offset to 0, creating sequence repeatablity for the above example.  This fix permits the mxnet test_random.py unittest to perform all tests on both cpu and gpu, where currently the sequence repeatablity tests are bypassed for gpu.  This fix also permits mxnet unittests to operate independently, which is important for test suite robustness and debuggability.