### PR TITLE
Add fully qualified type on define default_real_t

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -204,7 +204,7 @@ extern "C" {
  *  template arguments can be detected
  */
 #ifndef MSHADOW_DEFAULT_DTYPE
-#define MSHADOW_DEFAULT_DTYPE = default_real_t
+#define MSHADOW_DEFAULT_DTYPE = ::mshadow::default_real_t
 #endif
 
 /*!


### PR DESCRIPTION
This macro needs to have the full namespace definition in order to remove the "using namespace mshadow" from src/common/random_generator.h in mxnet introduced by 

https://github.com/apache/incubator-mxnet/commit/34a51959bd2bc21c6cfa93f5fe0e079ef5268261

https://github.com/apache/incubator-mxnet/pull/9321