### PR TITLE
Fix warning, add informative error messages when cuda drivers are not configured propperly

### DIFF
--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -8,7 +8,7 @@
 #  Add MSHADOW_NVCCFLAGS to the nvcc compile flags
 #----------------------------------------------------------------------------------------
 
-MSHADOW_CFLAGS = -funroll-loops -Wno-unused-variable -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-local-typedefs
+MSHADOW_CFLAGS = -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-local-typedefs
 MSHADOW_LDFLAGS = -lm
 MSHADOW_NVCCFLAGS =
 


### PR DESCRIPTION
 nvcc warning : '--device-debug (-G)' overrides '--generate-line-info (-lineinfo)'

Add an informative error message when no cuda devices are found.
@tqchen @cjolivier01 