### PR TITLE
Add half_t hash specialization

### DIFF
--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -275,7 +275,7 @@ MSHADOW_HALF_OPERATOR(bool, <=)
 namespace std {
 // specialization for std::hash<mshadow::half::half_t>
 template <> struct hash<mshadow::half::half_t> {
-  size_t operator()(const mshadow::half::half_t& x) const {
+  MSHADOW_XINLINE size_t operator()(const mshadow::half::half_t& x) const {
 #if MSHADOW_CUDA_HALF
     return std::hash<__half>()(x.cuhalf_);
 #endif  // MSHADOW_CUDA_HALF

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -276,7 +276,7 @@ namespace std {
 // specialization for std::hash<mshadow::half::half_t>
 template <> struct hash<mshadow::half::half_t> {
   MSHADOW_XINLINE size_t operator()(const mshadow::half::half_t& x) const {
-#if MSHADOW_CUDA_HALF
+#if (MSHADOW_CUDA_HALF && defined(__CUDA_ARCH__))
     return std::hash<__half>()(x.cuhalf_);
 #endif  // MSHADOW_CUDA_HALF
     return std::hash<uint16_t>()(x.half_);

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -271,4 +271,17 @@ MSHADOW_HALF_OPERATOR(bool, <=)
 #define MSHADOW_HALF_MAX mshadow::half::half_t::Binary(0x7BFF);
 }  // namespace half
 }  // namespace mshadow
+
+namespace std {
+// specialization for std::hash<mshadow::half::half_t>
+template <> struct hash<mshadow::half::half_t> {
+  size_t operator()(const mshadow::half::half_t& x) const {
+#if MSHADOW_CUDA_HALF
+    return std::hash<__half>()(x.cuhalf_);
+#endif  // MSHADOW_CUDA_HALF
+    return std::hash<uint16_t>()(x.half_);
+  }
+};
+}  // namespace std
+
 #endif  // MSHADOW_HALF_H_

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -141,16 +141,4 @@ MSHADOW_XINLINE bool operator==(half2_t a, half2_t b) {
 }  // namespace half
 }  // namespace mshadow
 
-namespace std {
-// specialization for std::hash<mshadow::half::half_t>
-template <> struct hash<mshadow::half::half_t> {
-  size_t operator()(const mshadow::half::half_t& x) const {
-#if MSHADOW_CUDA_HALF
-    LOG(FATAL) << "std::hash<__half> is undefined";
-#endif  // MSHADOW_CUDA_HALF
-    return std::hash<uint16_t>()(x.half_);
-  }
-};
-}  // namespace std
-
 #endif  // MSHADOW_HALF2_H_

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -142,15 +142,15 @@ MSHADOW_XINLINE bool operator==(half2_t a, half2_t b) {
 }  // namespace mshadow
 
 namespace std {
-  // specialization for std::hash<mshadow::half::half_t>
-  template <> struct hash<mshadow::half::half_t> {
-    size_t operator()(const mshadow::half::half_t& x) const {
+// specialization for std::hash<mshadow::half::half_t>
+template <> struct hash<mshadow::half::half_t> {
+  size_t operator()(const mshadow::half::half_t& x) const {
 #if MSHADOW_CUDA_HALF
-      LOG(FATAL) << "std::hash<__half> is undefined";
+    LOG(FATAL) << "std::hash<__half> is undefined";
 #endif  // MSHADOW_CUDA_HALF
-      return std::hash<uint16_t>()(x.half_);
-    }
-  };
-} // namespace std
+    return std::hash<uint16_t>()(x.half_);
+  }
+};
+}  // namespace std
 
 #endif  // MSHADOW_HALF2_H_

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -140,4 +140,16 @@ MSHADOW_XINLINE bool operator==(half2_t a, half2_t b) {
 
 }  // namespace half
 }  // namespace mshadow
+
+namespace std {
+  template <> struct hash<mshadow::half::half_t> {
+    size_t operator()(const mshadow::half::half_t& x) const {
+#if MSHADOW_CUDA_HALF
+      LOG(FATAL) << "std::hash<__half> is undefined";
+#endif  // MSHADOW_CUDA_HALF
+      return std::hash<uint16_t>()(x.half_);
+    }
+  };
+}
+
 #endif  // MSHADOW_HALF2_H_

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -142,6 +142,7 @@ MSHADOW_XINLINE bool operator==(half2_t a, half2_t b) {
 }  // namespace mshadow
 
 namespace std {
+  // specialization for std::hash<mshadow::half::half_t>
   template <> struct hash<mshadow::half::half_t> {
     size_t operator()(const mshadow::half::half_t& x) const {
 #if MSHADOW_CUDA_HALF
@@ -150,6 +151,6 @@ namespace std {
       return std::hash<uint16_t>()(x.half_);
     }
   };
-}
+} // namespace std
 
 #endif  // MSHADOW_HALF2_H_


### PR DESCRIPTION
Specialize `std::hash<half_t>` so that `std::unordered_map<DType>` can be used in MXNet. 
@piiswrong 