### PR TITLE
Revert "Add half_t hash specialization (#324)"

### DIFF
--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -271,17 +271,4 @@ MSHADOW_HALF_OPERATOR(bool, <=)
 #define MSHADOW_HALF_MAX mshadow::half::half_t::Binary(0x7BFF);
 }  // namespace half
 }  // namespace mshadow
-
-namespace std {
-// specialization for std::hash<mshadow::half::half_t>
-template <> struct hash<mshadow::half::half_t> {
-  MSHADOW_XINLINE size_t operator()(const mshadow::half::half_t& x) const {
-#if (MSHADOW_CUDA_HALF && defined(__CUDA_ARCH__))
-    return std::hash<__half>()(x.cuhalf_);
-#endif  // MSHADOW_CUDA_HALF
-    return std::hash<uint16_t>()(x.half_);
-  }
-};
-}  // namespace std
-
 #endif  // MSHADOW_HALF_H_

--- a/mshadow/half2.h
+++ b/mshadow/half2.h
@@ -140,5 +140,4 @@ MSHADOW_XINLINE bool operator==(half2_t a, half2_t b) {
 
 }  // namespace half
 }  // namespace mshadow
-
 #endif  // MSHADOW_HALF2_H_


### PR DESCRIPTION
This reverts commit 1a830238481578e480e202adb258c988c4b2528e.
The previous PR was not properly tested with CUDA. @piiswrong 