### PR TITLE
May want to define NOMINMAX at a higher level

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -14,7 +14,9 @@
 #ifndef _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_DEPRECATE
 #endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #endif
 #include <cmath>
 #include <cstdio>


### PR DESCRIPTION
For example, may want to define for dmlc-core usage (a situation like mxnet where dmlc-core and mshadow are both used), but that definition may cause a warning here