### PR TITLE
Leveraging F16C x86 instruction set architecture extension for half datatype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.7)
 
 project(mshadow C CXX)
+
 set(mshadow_LINT_DIRS mshadow mshadow-ps)
 add_custom_target(mshadow_lint COMMAND ${CMAKE_COMMAND} -DMSVC=${MSVC} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DLINT_DIRS=${mshadow_LINT_DIRS} -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR} -DPROJECT_NAME=mshadow -P ${PROJECT_SOURCE_DIR}/../dmlc-core/cmake/lint.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.7)
 
 project(mshadow C CXX)
-
 set(mshadow_LINT_DIRS mshadow mshadow-ps)
 add_custom_target(mshadow_lint COMMAND ${CMAKE_COMMAND} -DMSVC=${MSVC} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DLINT_DIRS=${mshadow_LINT_DIRS} -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR} -DPROJECT_NAME=mshadow -P ${PROJECT_SOURCE_DIR}/../dmlc-core/cmake/lint.cmake)

--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -48,17 +48,17 @@ else()
 	add_definitions(-DMSHADOW_USE_SSE=0)
 endif()
 
-if(NOT DEFINED SUPPORT_MF16C)
+if(NOT DEFINED SUPPORT_MF16C AND NOT MSVC)
     check_cxx_compiler_flag("-mf16c"     COMPILER_SUPPORT_MF16C)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         execute_process(COMMAND cat /proc/cpuinfo
                 COMMAND grep flags
-                COMMAND tail grep f16c
+                COMMAND grep f16c
                 OUTPUT_VARIABLE CPU_SUPPORT_F16C)
-    elseif(CMAKE_SYSTEM_NAME_STREQUAL "Darwin")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         execute_process(COMMAND sysctl -a
                 COMMAND grep machdep.cpu.features
-                COMMAND F16C
+                COMMAND grep F16C
                 OUTPUT_VARIABLE CPU_SUPPORT_F16C)
     endif()
     if(CPU_SUPPORT_F16C AND COMPILER_SUPPORT_MF16C)
@@ -68,6 +68,7 @@ endif()
 
 if(SUPPORT_MF16C)
     add_definitions(-DMSHADOW_USE_F16C=1)
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -mf16c")
 else()
     add_definitions(-DMSHADOW_USE_F16C=0)
 endif()

--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -48,6 +48,24 @@ else()
 	add_definitions(-DMSHADOW_USE_SSE=0)
 endif()
 
+if(NOT DEFINED SUPPORT_MF16C)
+    check_cxx_compiler_flag("-mf16c"     COMPILER_SUPPORT_MF16C)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        execute_process(COMMAND cat /proc/cpuinfo
+                COMMAND grep flags
+                COMMAND tail grep f16c
+                OUTPUT_VARIABLE CPU_SUPPORT_F16C)
+    elseif(CMAKE_SYSTEM_NAME_STREQUAL "Darwin")
+        execute_process(COMMAND sysctl -a
+                COMMAND grep machdep.cpu.features
+                COMMAND F16C
+                OUTPUT_VARIABLE CPU_SUPPORT_F16C)
+    endif()
+    if(CPU_SUPPORT_F16C AND COMPILER_SUPPORT_MF16C)
+        set(SUPPORT_MF16C TRUE)
+    endif()
+endif()
+
 if(SUPPORT_MF16C)
     add_definitions(-DMSHADOW_USE_F16C=1)
 else()

--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -48,6 +48,12 @@ else()
 	add_definitions(-DMSHADOW_USE_SSE=0)
 endif()
 
+if(SUPPORT_MF16C)
+    add_definitions(-DMSHADOW_USE_F16C=1)
+else()
+    add_definitions(-DMSHADOW_USE_F16C=0)
+endif()
+
 if(USE_CUDA)
 	find_package(CUDA 5.5 QUIET)
 	find_cuda_helper_libs(curand)

--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -25,10 +25,6 @@ ifndef USE_SSE
 	USE_SSE=1
 endif
 
-ifndef USE_F16C
-    USE_F16C=1
-endif
-
 ifeq ($(USE_SSE), 1)
 	MSHADOW_CFLAGS += -msse3
 else
@@ -44,7 +40,7 @@ ifndef USE_F16C
         ifeq ($(detected_OS),Linux)
             F16C_SUPP = $(shell cat /proc/cpuinfo | grep flags | grep f16c)
         endif
-        ifneq ($(F16C_SUPP), NONE)
+	ifneq ($(F16C_SUPP), NONE)
                 USE_F16C=1
         else
                 USE_F16C=0

--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -48,7 +48,7 @@ ifndef USE_F16C
     endif
     # if OS is Windows, check if your processor supports F16C architecture.
     # One way to do that is to download the tool https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo.
-    # If coreinfo -c shows F16C then you can set F16C=1 explicitly to leverage that capability"
+    # If coreinfo -c shows F16C then you can set USE_F16C=1 explicitly to leverage that capability"
 endif
 
 ifeq ($(USE_F16C), 1)

--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -25,10 +25,20 @@ ifndef USE_SSE
 	USE_SSE=1
 endif
 
+ifndef USE_F16C
+    USE_F16C=1
+endif
+
 ifeq ($(USE_SSE), 1)
 	MSHADOW_CFLAGS += -msse3
 else
 	MSHADOW_CFLAGS += -DMSHADOW_USE_SSE=0
+endif
+
+ifeq ($(USE_F16C), 1)
+	MSHADOW_CFLAGS += -mf16c
+else
+	MSHADOW_CFLAGS += -DMSHADOW_USE_F16C=0
 endif
 
 ifeq ($(USE_CUDA), 0)

--- a/make/mshadow.mk
+++ b/make/mshadow.mk
@@ -35,10 +35,30 @@ else
 	MSHADOW_CFLAGS += -DMSHADOW_USE_SSE=0
 endif
 
+ifndef USE_F16C
+    ifneq ($(OS),Windows_NT)
+        detected_OS := $(shell uname -s)
+        ifeq ($(detected_OS),Darwin)
+            F16C_SUPP = $(shell sysctl -a | grep machdep.cpu.features | grep F16C)
+        endif
+        ifeq ($(detected_OS),Linux)
+            F16C_SUPP = $(shell cat /proc/cpuinfo | grep flags | grep f16c)
+        endif
+        ifneq ($(F16C_SUPP), NONE)
+                USE_F16C=1
+        else
+                USE_F16C=0
+        endif
+    endif
+    # if OS is Windows, check if your processor supports F16C architecture.
+    # One way to do that is to download the tool https://docs.microsoft.com/en-us/sysinternals/downloads/coreinfo.
+    # If coreinfo -c shows F16C then you can set F16C=1 explicitly to leverage that capability"
+endif
+
 ifeq ($(USE_F16C), 1)
-	MSHADOW_CFLAGS += -mf16c
+        MSHADOW_CFLAGS += -mf16c
 else
-	MSHADOW_CFLAGS += -DMSHADOW_USE_F16C=0
+        MSHADOW_CFLAGS += -DMSHADOW_USE_F16C=0
 endif
 
 ifeq ($(USE_CUDA), 0)

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -133,7 +133,7 @@ typedef unsigned __int64 uint64_t;
   #define MSHADOW_USE_SSE 1
 #endif
 
-/*! \brief whether use SSE */
+/*! \brief whether use F16C instruction set architecture extension */
 #ifndef MSHADOW_USE_F16C
 #define MSHADOW_USE_F16C 1
 #endif

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -132,6 +132,12 @@ typedef unsigned __int64 uint64_t;
 #ifndef MSHADOW_USE_SSE
   #define MSHADOW_USE_SSE 1
 #endif
+
+/*! \brief whether use SSE */
+#ifndef MSHADOW_USE_F16C
+#define MSHADOW_USE_F16C 1
+#endif
+
 /*! \brief whether use NVML to get dynamic info */
 #ifndef MSHADOW_USE_NVML
   #define MSHADOW_USE_NVML 0

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -255,7 +255,7 @@ class MSHADOW_ALIGNED(2) half_t {
 #if (MSHADOW_CUDA_HALF && defined(__CUDA_ARCH__))
     cuhalf_ = __float2half(float(value));  // NOLINT(*)
 #elif (MSHADOW_USE_F16C)
-    half_ = _cvtss_sh(value, 0);
+    half_ = _cvtss_sh((float) value, 0);
 #else /* !MSHADOW_CUDA_HALF and !MSHADOW_USE_F16C */
     half_ = float2half(float(value));  // NOLINT(*)
 #endif /* !MSHADOW_CUDA_HALF and !MSHADOW_USE_F16C */

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -8,9 +8,11 @@
 #ifndef MSHADOW_HALF_H_
 #define MSHADOW_HALF_H_
 #include "./base.h"
+
 #if MSHADOW_USE_F16C
-#include <x86intrin.h>
+  #include <x86intrin.h>
 #endif // MSHADOW_USE_F16C
+
 #if (MSHADOW_USE_CUDA && CUDA_VERSION >= 7050)
   #define MSHADOW_CUDA_HALF 1
   #include <cuda_fp16.h>
@@ -76,7 +78,7 @@ namespace half {
 #else
 #define MSHADOW_HALF_CONVERSIONOP(T)                                      \
   MSHADOW_XINLINE operator T() const {                                    \
-  return T(half2float(half_));  /* NOLINT(*)*/                            \
+    return T(half2float(half_));  /* NOLINT(*)*/                          \
   }                                                                       \
   MSHADOW_XINLINE operator T() const volatile {                           \
     return T(half2float(half_));  /* NOLINT(*)*/                          \
@@ -256,9 +258,9 @@ class MSHADOW_ALIGNED(2) half_t {
     cuhalf_ = __float2half(float(value));  // NOLINT(*)
 #elif (MSHADOW_USE_F16C)
     half_ = _cvtss_sh((float) value, 0);
-#else /* !MSHADOW_CUDA_HALF and !MSHADOW_USE_F16C */
+#else /* !MSHADOW_CUDA_HALF && !MSHADOW_USE_F16C */
     half_ = float2half(float(value));  // NOLINT(*)
-#endif /* !MSHADOW_CUDA_HALF and !MSHADOW_USE_F16C */
+#endif /* !MSHADOW_CUDA_HALF && !MSHADOW_USE_F16C */
   }
 };
 

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -67,7 +67,7 @@ namespace half {
   MSHADOW_XINLINE operator T() const volatile {                           \
     return T(__half2float_warp(cuhalf_));  /* NOLINT(*)*/                 \
   }
-#elif (MSHADOW_USE_F16C)
+#elif(MSHADOW_USE_F16C)
 #define MSHADOW_HALF_CONVERSIONOP(T)                                      \
   MSHADOW_XINLINE operator T() const {                                    \
     return T(_cvtsh_ss(half_));   /* NOLINT(*)*/                          \
@@ -256,8 +256,8 @@ class MSHADOW_ALIGNED(2) half_t {
   MSHADOW_XINLINE void constructor(const T& value) {
 #if (MSHADOW_CUDA_HALF && defined(__CUDA_ARCH__))
     cuhalf_ = __float2half(float(value));  // NOLINT(*)
-#elif (MSHADOW_USE_F16C)
-    half_ = _cvtss_sh((float) value, 0);
+#elif(MSHADOW_USE_F16C)
+    half_ = _cvtss_sh(static_cast<float>(value), 0);
 #else /* !MSHADOW_CUDA_HALF && !MSHADOW_USE_F16C */
     half_ = float2half(float(value));  // NOLINT(*)
 #endif /* !MSHADOW_CUDA_HALF && !MSHADOW_USE_F16C */

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -11,7 +11,7 @@
 
 #if MSHADOW_USE_F16C
   #include <x86intrin.h>
-#endif // MSHADOW_USE_F16C
+#endif  // MSHADOW_USE_F16C
 
 #if (MSHADOW_USE_CUDA && CUDA_VERSION >= 7050)
   #define MSHADOW_CUDA_HALF 1


### PR DESCRIPTION
Leveraging F16C x86 instruction set architecture extension for fast conversions of half to float and back for computations with `half`

F16C seems to be introduced many years back. Intel first announced support for this from Ivy Bridge in 2012. Most processors we would use these days (Intel or AMD) would have support for these intrinsics for fast conversion. Clang, gcc and intel compiler all support this. I tested this on Mac and EC2 p3.8x Ubuntu. Both CMake and Make.

Speedup  **8 times** over existing float2half and half2float methods.

Even with this change, as of now fp16 on cpu is about 3x slower on p3.8x machine than fp32 as below.
```
Time for 10000 additions of two 1000x1000 ndarrays:
fp32: 0.67s
fp16: 1.96s
```
Before this PR, current mshadow 
```
fp16: 15.56s
```

References: 
- [F16C on Wikipedia](https://en.wikipedia.org/wiki/F16C)
- [Intel blogpost on half precision for CPU](https://software.intel.com/en-us/articles/performance-benefits-of-half-precision-floats)


