### PR TITLE
Fix F16C build for cmake with certain versions of nvcc and gcc

### DIFF
--- a/cmake/mshadow.cmake
+++ b/cmake/mshadow.cmake
@@ -70,7 +70,6 @@ if(NOT DEFINED SUPPORT_F16C AND NOT MSVC)
 endif()
 
 if(SUPPORT_F16C)
-    add_definitions(-DMSHADOW_USE_F16C=1)
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -mf16c")
 else()
     add_definitions(-DMSHADOW_USE_F16C=0)


### PR DESCRIPTION
This miss got left out in the previous commit. For CMake this was setting the DMSHADOW_USE_F16C to 1 when being used so CUDACC still sees it and causes issues. 

This should fix https://github.com/apache/incubator-mxnet/issues/10558#issuecomment-385804894 because of https://github.com/dmlc/mshadow/blob/5da1d9084e56bf1d7af246f632f4d59a995c76cd/mshadow/base.h#L139