### PR TITLE
Improved random number generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - wget
       - unzip
       - libblas-dev
+      - python3-pip
 
 before_install:
   - git clone https://github.com/dmlc/dmlc-core
@@ -23,7 +24,7 @@ before_install:
   - source ${TRAVIS}/travis_setup_env.sh
 
 install:
-  - pip install  --user  cpplint pylint
+  - pip3 install  --user  cpplint pylint
   
 script: scripts/travis_script.sh
 

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -410,6 +410,36 @@ struct DataType<int64_t> {
 /*! \brief type enum value for default real type */
 const int default_type_flag = DataType<default_real_t>::kFlag;
 
+#if MSHADOW_IN_CXX11
+
+/*! \brief replace std::is_integral to support half_t */
+template<typename T>
+struct IsIntegral {
+  using value_type = bool;
+  constexpr static value_type value = std::is_integral<T>::value;
+};
+
+template<>
+struct IsIntegral<half::half_t> {
+  using value_type = bool;
+  constexpr static value_type value = false;
+};
+
+/*! \brief replace std::is_floating_point to support half_t */
+template<typename T>
+struct IsFloatingPoint {
+  using value_type = bool;
+  constexpr static value_type value = std::is_floating_point<T>::value;
+};
+
+template<>
+struct IsFloatingPoint<half::half_t> {
+  using value_type = bool;
+  constexpr static value_type value = true;
+};
+
+#endif
+
 /*! layout flag */
 enum LayoutFlag {
   kNCHW = 0,

--- a/mshadow/cuda/cumath.cuh
+++ b/mshadow/cuda/cumath.cuh
@@ -1,0 +1,75 @@
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file cumath.cuh
+ * \brief generic interface for cuda arithmetic and math intrinsics
+ * \author Deokjae Lee
+ */
+#ifndef MSHADOW_CUDA_CUMATH_CUH_
+#define MSHADOW_CUDA_CUMATH_CUH_
+
+#ifdef __CUDACC__
+
+namespace mshadow {
+namespace cuda {
+
+template<typename DType>
+struct CuMath;
+
+template<>
+struct CuMath<float> {
+  using DType = float;
+  MSHADOW_FORCE_INLINE __device__ static DType Log(DType f) {
+    return ::__logf(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Sqrt(DType f) {
+    return ::__fsqrt_rn(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Cos(DType f) {
+    return ::__cosf(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Sin(DType f) {
+    return ::__sinf(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Abs(DType f) {
+    return ::fabsf(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Fma(DType f1, DType f2, DType f3) {
+    return ::__fmaf_rn(f1, f2, f3);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType FmaRD(DType f1, DType f2, DType f3) {
+    return ::__fmaf_rd(f1, f2, f3);
+  }
+};
+
+template<>
+struct CuMath<double> {
+  using DType = double;
+  MSHADOW_FORCE_INLINE __device__ static DType Log(DType f) {
+    return ::log(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Sqrt(DType f) {
+    return __dsqrt_rn(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Cos(DType f) {
+    return ::cos(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Sin(DType f) {
+    return ::sin(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Abs(DType f) {
+    return ::fabs(f);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType Fma(DType f1, DType f2, DType f3) {
+    return ::__fma_rn(f1, f2, f3);
+  }
+  MSHADOW_FORCE_INLINE __device__ static DType FmaRD(DType f1, DType f2, DType f3) {
+    return ::__fma_rd(f1, f2, f3);
+  }
+};
+
+}  // namespace cuda
+}  // namespace mshadow
+
+#endif  // __CUDACC__
+
+#endif  // MSHADOW_CUDA_CUMATH_CUH_

--- a/mshadow/cuda/random_gpu.cuh
+++ b/mshadow/cuda/random_gpu.cuh
@@ -1,0 +1,513 @@
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file random_gpu.cuh
+ * \brief random number generator implementation using CUDA
+ * \author Deokjae Lee
+ */
+#ifndef MSHADOW_CUDA_RANDOM_GPU_CUH_
+#define MSHADOW_CUDA_RANDOM_GPU_CUH_
+
+#include <limits>
+#include <type_traits>
+#include "cumath.cuh"
+
+namespace mshadow {
+namespace cuda {
+
+template<typename Rng, typename DType>
+struct GPURandomImpl {
+  /*!
+   * \brief allocate internal parallel random number generators of `impl`.
+   * \param stream cuda stream
+   * \param seed seed for `impl`
+   * \param sequence_id sequence id for `impl`.
+   *        Generators with different sequence ids are statistically independent.
+   * \param n_rngs number of internal parallel random generators.
+   */
+  static void AllocState(
+    cudaStream_t stream,
+    GPURandomImpl<Rng, DType>* impl,
+    uint64_t seed,
+    uint32_t sequence_id,
+    unsigned n_rngs
+  );
+
+  static void FreeState(GPURandomImpl<Rng, DType>* impl);
+
+  /*!
+   * \brief seed this generator
+   * \param stream cuda stream
+   * \param seed seed for the generator
+   * \param sequence_id sequence id for the generator
+   *        Generators with different sequence ids are statistically independent.
+   */
+  inline void Seed(cudaStream_t stream, uint64_t seed, uint32_t sequence_id);
+
+  /*!
+   * \brief get a set of random integers
+   * \param stream cuda stream
+   * \param dst destination
+   * \param size number of random numbers to draw
+   * \tparam IntType any integer type
+   */
+  template<typename IntType>
+  inline void GenerateInt(cudaStream_t stream, IntType* dst, size_t size);
+
+  /*!
+   * \brief generate uniformly distributed random numbers
+   * \param stream cuda stream
+   * \param dst destination
+   * \param size number of random numbers to draw
+   * \param a lower bound of the distribution. inclusive
+   * \param b upper bound of the distribution. inclusive if `DType` is integer and exclusive otherwise.
+   */
+  inline void GenerateUniform(
+    cudaStream_t stream,
+    DType* dst,
+    size_t size,
+    DType a = 0,
+    DType b = 1
+  );
+
+  /*!
+   * \brief generate data from Gaussian distribution
+   * \param stream cuda stream
+   * \param dst destination
+   * \param size number of random numbers to draw
+   * \param mean mean
+   * \param stddev standard deviation
+   */
+  inline void GenerateGaussian(
+    cudaStream_t stream,
+    DType* dst,
+    size_t size,
+    DType mean = 0,
+    DType stddev = 1
+  );
+
+ private:
+  /*! \brief random generators in parallel use */
+  Rng* rngs;
+  /*! \brief the number of parallel random generators */
+  unsigned n_rngs;
+  /*! \brief the number of cuda threads per block */
+  unsigned n_threads;
+  /*! \brief the number of cuda blocks */
+  unsigned n_blocks;
+};
+
+#ifdef __CUDACC__
+
+template<typename Rng>
+__global__ void RandomInitKernel(
+  Rng* const rngs,
+  const uint64_t seed,
+  const uint64_t stream_offset
+) {
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  rngs[rng_id] = Rng(seed, stream_offset + rng_id);
+}
+
+template<typename Rng>
+__global__ void RandomSeedKernel(
+  Rng* const rngs,
+  const uint64_t seed,
+  const uint64_t stream_offset
+) {
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  rngs[rng_id].seed(seed, stream_offset + rng_id);
+}
+
+template<typename IntType, typename Rng>
+__global__ void RandomUIntKernel(
+  Rng* const rngs,
+  const unsigned n_rngs,
+  const size_t size,
+  IntType* const ret
+) {
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  Rng rng = rngs[rng_id];
+  IntType* const bound = ret + n_rngs * (size / n_rngs);
+  for (IntType* offset = ret; offset < bound; offset += n_rngs) {
+    *(offset + rng_id) = static_cast<IntType>(rng());
+  }
+  if (rng_id < size % n_rngs) {
+    *(bound + rng_id) = static_cast<IntType>(rng());
+  }
+  rngs[rng_id] = rng;
+}
+
+template<typename From, typename To>
+MSHADOW_FORCE_INLINE __device__ To CastWithRounginDown(From f) {
+  return f;
+}
+
+template<>
+MSHADOW_FORCE_INLINE __device__ mshadow::half::half_t CastWithRounginDown(float f) {
+  return mshadow::half::half_t(__float2half_rd(f));
+}
+
+template<typename Rng, typename DType>
+__global__ void RandomUniformRealKernel(
+  Rng* const rngs,
+  const unsigned n_rngs,
+  const DType lo,
+  const DType hi,
+  const size_t size,
+  DType* const ret
+) {
+  using FType = typename std::conditional<sizeof(DType) <= 4, float, double>::type;
+  using CM = CuMath<FType>;
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  Rng rng = rngs[rng_id];
+  const FType w = hi - lo;
+  DType* const bound = ret + n_rngs * (size / n_rngs);
+  for (DType* offset = ret; offset < bound; offset += n_rngs) {
+    // Rounding down is used to ensure the upper bound exclusive.
+    *(offset + rng_id) = CastWithRounginDown<FType, DType>(
+      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(rng)), w, lo)
+    );
+  }
+  if (rng_id < size % n_rngs) {
+    // Rounding down is used to ensure the upper bound exclusive.
+    *(bound + rng_id) = CastWithRounginDown<FType, DType>(
+      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(rng)), w, lo)
+    );
+  }
+  rngs[rng_id] = rng;
+}
+
+template<typename Rng, typename DType>
+__global__ void RandomUniformIntKernel(
+  Rng* const rngs,
+  const unsigned n_rngs,
+  const DType lo,
+  const DType hi,
+  const size_t size,
+  DType* const ret
+) {
+  using UIType = typename Rng::result_type;
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  Rng rng = rngs[rng_id];
+  DType* const bound = ret + n_rngs * (size / n_rngs);
+  if (static_cast<UIType>(hi - lo) == rng.max()) {
+    for (DType* offset = ret; offset < bound; offset += n_rngs) {
+      *(offset + rng_id) = rng();
+    }
+    if (rng_id < size % n_rngs) {
+      *(bound + rng_id) = rng();
+    }
+  } else {
+    const UIType w = static_cast<UIType>(hi - lo) + 1;
+    const UIType v = Rng::max() - Rng::max() % w;
+    for (DType* offset = ret; offset < bound; offset += n_rngs) {
+      UIType r = rng();
+      while (r >= v) {
+        r = rng();
+      }
+      *(offset + rng_id) = lo + static_cast<DType>(r % w);
+    }
+    if (rng_id < size % n_rngs) {
+      UIType r = rng();
+      while (r >= v) {
+        r = rng();
+      }
+      *(bound + rng_id) = lo + static_cast<DType>(r % w);
+    }
+  }
+  rngs[rng_id] = rng;
+}
+
+template<typename Rng, typename DType>
+__global__ void RandomGaussianKernel(
+  Rng* const rngs,
+  const unsigned n_rngs,
+  const DType mean,
+  const DType stddev,
+  const size_t size,
+  DType* const ret
+) {
+  // Box-Muller method
+  using FType = typename std::conditional<sizeof(DType) <= 4, float, double>::type;
+  using CM = CuMath<FType>;
+  const FType two_pi = 6.283185307179586;
+  const size_t rng_id = blockIdx.x * blockDim.x + threadIdx.x;
+  Rng rng = rngs[rng_id];
+  DType* const bound1 = ret + 2 * n_rngs * (size / (2 * n_rngs));
+  DType* const bound2 = ret + size;
+  for (DType* offset = ret; offset < bound1; offset += 2 * n_rngs) {
+    FType u1 = RandomReal<Rng, FType>::Generate(rng);
+    while (u1 == 0) {
+      u1 = RandomReal<Rng, FType>::Generate(rng);
+    }
+    const FType u2 = RandomReal<Rng, FType>::Generate(rng);
+    const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
+    const FType v2 = two_pi * u2;
+    *(offset + rng_id) = static_cast<DType>(CM::Fma(v1, CM::Cos(v2), mean));
+    DType* i = offset + n_rngs + rng_id;
+    *i = static_cast<DType>(CM::Fma(v1, CM::Sin(v2), mean));
+  }
+  if (2 * rng_id < size % (2 * n_rngs)) {
+    FType u1 = RandomReal<Rng, FType>::Generate(rng);
+    while (u1 == 0) {
+      u1 = RandomReal<Rng, FType>::Generate(rng);
+    }
+    const FType u2 = RandomReal<Rng, FType>::Generate(rng);
+    const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
+    const FType v2 = two_pi * u2;
+    DType* i = bound1 + 2 * rng_id;
+    *i = static_cast<DType>(CM::Fma(v1, CM::Cos(v2), mean));
+    if (i + 1 < bound2) {
+      *(i + 1) = static_cast<DType>(CM::Fma(v1, CM::Sin(v2), mean));
+    }
+  }
+  rngs[rng_id] = rng;
+}
+
+template<typename DType>
+struct RandomUniformRealKernelSelector {
+  template<typename Rng>
+  MSHADOW_FORCE_INLINE static void Launch(
+    Rng* const rngs,
+    const unsigned n_rngs,
+    const DType lo,
+    const DType hi,
+    const size_t size,
+    DType* const ret,
+    const unsigned n_blocks,
+    const unsigned n_threads,
+    cudaStream_t s
+  ) {
+    RandomUniformRealKernel<<<dim3(n_blocks, 1, 1), n_threads, 0, s>>>(
+      rngs, n_rngs, lo, hi, size, ret
+    );
+  }
+};
+
+template<typename DType>
+struct RandomUniformKernelSelector {
+  template<typename Rng>
+  MSHADOW_FORCE_INLINE static void Launch(
+    Rng* const rngs,
+    const unsigned n_rngs,
+    const DType lo,
+    const DType hi,
+    const size_t size,
+    DType* const ret,
+    const unsigned n_blocks,
+    const unsigned n_threads,
+    cudaStream_t s
+  ) {
+    RandomUniformIntKernel<<<dim3(n_blocks, 1, 1), n_threads, 0, s>>>(
+      rngs, n_rngs, lo, hi, size, ret
+    );
+  }
+};
+
+template<>
+struct RandomUniformKernelSelector<float>
+: public RandomUniformRealKernelSelector<float> {};
+
+template<>
+struct RandomUniformKernelSelector<double>
+: public RandomUniformRealKernelSelector<double> {};
+
+template<>
+struct RandomUniformKernelSelector<half::half_t>
+: public RandomUniformRealKernelSelector<half::half_t> {};
+
+
+template<typename Rng, typename DType>
+void GPURandomImpl<Rng, DType>::AllocState(
+  cudaStream_t s,
+  GPURandomImpl<Rng, DType>* impl,
+  const uint64_t seed,
+  const uint32_t sequence_id,
+  const unsigned n_rngs
+) {
+  CHECK_GT(n_rngs, 0) << "The number of internal random number generators must be positive";
+  const unsigned max_threads_per_block = 64;
+  impl->n_rngs = n_rngs;
+  if (n_rngs <= max_threads_per_block) {
+    impl->n_blocks = 1;
+    impl->n_threads = n_rngs;
+  } else {
+    impl->n_blocks = 1 + (n_rngs - 1) / max_threads_per_block;
+    impl->n_threads = max_threads_per_block;
+  }
+  MSHADOW_CUDA_CALL(cudaMalloc(&impl->rngs, sizeof(Rng) * n_rngs));
+  const uint64_t stream_offset = uint64_t(sequence_id) * std::numeric_limits<uint32_t>::max();
+  cuda::RandomInitKernel<<<dim3(impl->n_blocks, 1, 1), impl->n_threads, 0, s>>>(
+    impl->rngs, seed, stream_offset
+  );
+  MSHADOW_CUDA_POST_KERNEL_CHECK(RandomInitKernel);
+}
+
+template<typename Rng, typename DType>
+void GPURandomImpl<Rng, DType>::FreeState(GPURandomImpl<Rng, DType>* impl) {
+  MSHADOW_CUDA_CALL(cudaFree(impl->rngs));
+}
+
+template<typename Rng, typename DType>
+inline void GPURandomImpl<Rng, DType>::Seed(
+  cudaStream_t s,
+  const uint64_t seed,
+  const uint32_t sequence_id
+) {
+  const uint64_t stream_offset = uint64_t(sequence_id) * std::numeric_limits<uint32_t>::max();
+  RandomSeedKernel<<<dim3(n_blocks, 1, 1), n_threads, 0, s>>>(rngs, seed, stream_offset);
+  MSHADOW_CUDA_POST_KERNEL_CHECK(RandomSeedKernel);
+}
+
+template<typename Rng, typename DType>
+template<typename IntType>
+inline void GPURandomImpl<Rng, DType>::GenerateInt(
+  cudaStream_t s,
+  IntType* const dst,
+  const size_t size
+) {
+  RandomUIntKernel<<<dim3(n_blocks, 1, 1), n_threads, 0, s>>>(
+    rngs, n_rngs, size, dst
+  );
+  MSHADOW_CUDA_POST_KERNEL_CHECK(RandomUniformKernel);
+}
+
+template<typename Rng, typename DType>
+inline void GPURandomImpl<Rng, DType>::GenerateUniform(
+  cudaStream_t s,
+  DType* const dst,
+  const size_t size,
+  const DType a,
+  const DType b
+) {
+  RandomUniformKernelSelector<DType>::Launch(
+    rngs, n_rngs, a, b, size, dst, n_blocks, n_threads, s
+  );
+  MSHADOW_CUDA_POST_KERNEL_CHECK(RandomUniformKernel);
+}
+
+template<typename Rng, typename DType>
+inline void GPURandomImpl<Rng, DType>::GenerateGaussian(
+  cudaStream_t s,
+  DType* const dst,
+  const size_t size,
+  const DType mean,
+  const DType stddev
+) {
+  RandomGaussianKernel<<<dim3(n_blocks, 1, 1), n_threads, 0, s>>>(
+    rngs, n_rngs, mean, stddev, size, dst
+  );
+  MSHADOW_CUDA_POST_KERNEL_CHECK(RandomGaussianKernel);
+}
+
+// Explicit instantiations.
+// Sometimes needed to link object files separately compiled with nvcc and a host native compiler.
+// For example, mxnet requires this.
+template struct GPURandomImpl<PCGRandom64, double>;
+template struct GPURandomImpl<PCGRandom64, uint64_t>;
+template struct GPURandomImpl<PCGRandom64, int64_t>;
+template struct GPURandomImpl<PCGRandom32, float>;
+template struct GPURandomImpl<PCGRandom32, mshadow::half::half_t>;
+template struct GPURandomImpl<PCGRandom32, uint32_t>;
+template struct GPURandomImpl<PCGRandom32, int32_t>;
+template struct GPURandomImpl<PCGRandom32, uint16_t>;
+template struct GPURandomImpl<PCGRandom32, int16_t>;
+template struct GPURandomImpl<PCGRandom32, uint8_t>;
+template struct GPURandomImpl<PCGRandom32, int8_t>;
+
+#endif  // __CUDACC__
+
+}  // namespace cuda
+
+#ifdef __CUDACC__
+
+template<typename Rng, typename DType>
+struct UniformRealDistribution<gpu, Rng, DType> {
+
+  using result_type = DType;
+
+  MSHADOW_FORCE_INLINE __device__
+  explicit UniformRealDistribution(result_type a = 0, result_type b = 1)
+  : a(a), b(b), w(FType(b) - FType(a)) {
+  }
+
+  /*!
+   * \brief return a uniform random number assuming that `g` generates the full range of ingeters.
+   */
+  MSHADOW_FORCE_INLINE __device__ result_type operator()(Rng& g) const {
+    using CM = cuda::CuMath<FType>;
+    return cuda::CastWithRounginDown<FType, DType>(
+      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(g)), w, a)
+    );
+  }
+
+  private:
+    using FType = typename std::conditional<sizeof(DType) <= 4, float, double>::type;
+
+    FType a;
+    DType b;
+    FType w;
+};
+
+template<typename Rng, typename DType>
+struct GaussianDistribution<gpu, Rng, DType> {
+  using result_type = DType;
+
+  MSHADOW_FORCE_INLINE __device__
+  explicit GaussianDistribution(result_type mean = 0, result_type stddev = 1)
+  : mean(mean), stddev(stddev), spare(0), has_spare(false) {
+  }
+
+  /*!
+   * \brief return a Gaussian random number assuming that `g` generates the full range of ingeters.
+   */
+  MSHADOW_FORCE_INLINE __device__
+  result_type operator()(Rng& g) {
+    // Box-Muller method
+    if (has_spare) {
+      has_spare = false;
+      return spare;
+    }
+    using CM = cuda::CuMath<FType>;
+    const FType two_pi = 6.283185307179586;
+    FType u1 = RandomReal<Rng, FType>::Generate(g);
+    while (u1 == 0) {
+      u1 = RandomReal<Rng, FType>::Generate(g);
+    }
+    const FType u2 = RandomReal<Rng, FType>::Generate(g);
+    const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
+    const FType v2 = two_pi * u2;
+    spare = CM::Fma(v1, CM::Cos(v2), mean);
+    has_spare = true;
+    return static_cast<DType>(CM::Fma(v1, CM::Sin(v2), mean));
+  }
+
+ private:
+  using FType = typename std::conditional<sizeof(DType) <= 4, float, double>::type;
+
+  FType mean;
+  FType stddev;
+  FType spare;
+  bool has_spare;
+};
+
+// Explicit instantiations.
+// Sometimes needed to link object files separately compiled with nvcc and a host native compiler.
+template struct UniformRealDistribution<gpu, PCGRandom32, float>;
+template struct UniformRealDistribution<gpu, PCGRandom32, double>;
+template struct UniformRealDistribution<gpu, PCGRandom32, mshadow::half::half_t>;
+template struct UniformRealDistribution<gpu, PCGRandom64, float>;
+template struct UniformRealDistribution<gpu, PCGRandom64, double>;
+template struct UniformRealDistribution<gpu, PCGRandom64, mshadow::half::half_t>;
+template struct GaussianDistribution<gpu, PCGRandom32, float>;
+template struct GaussianDistribution<gpu, PCGRandom32, double>;
+template struct GaussianDistribution<gpu, PCGRandom32, mshadow::half::half_t>;
+template struct GaussianDistribution<gpu, PCGRandom64, float>;
+template struct GaussianDistribution<gpu, PCGRandom64, double>;
+template struct GaussianDistribution<gpu, PCGRandom64, mshadow::half::half_t>;
+
+#endif  // __CUDACC__
+
+}  // namespace mshadow
+
+#endif  // MSHADOW_CUDA_RANDOM_GPU_CUH_

--- a/mshadow/cuda/random_gpu.cuh
+++ b/mshadow/cuda/random_gpu.cuh
@@ -165,13 +165,13 @@ __global__ void RandomUniformRealKernel(
   for (DType* offset = ret; offset < bound; offset += n_rngs) {
     // Rounding down is used to ensure the upper bound exclusive.
     *(offset + rng_id) = CastWithRounginDown<FType, DType>(
-      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(rng)), w, lo)
+      CM::FmaRD(rng.template generate<FType>(), w, lo)
     );
   }
   if (rng_id < size % n_rngs) {
     // Rounding down is used to ensure the upper bound exclusive.
     *(bound + rng_id) = CastWithRounginDown<FType, DType>(
-      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(rng)), w, lo)
+      CM::FmaRD(rng.template generate<FType>(), w, lo)
     );
   }
   rngs[rng_id] = rng;
@@ -236,11 +236,11 @@ __global__ void RandomGaussianKernel(
   DType* const bound1 = ret + 2 * n_rngs * (size / (2 * n_rngs));
   DType* const bound2 = ret + size;
   for (DType* offset = ret; offset < bound1; offset += 2 * n_rngs) {
-    FType u1 = RandomReal<Rng, FType>::Generate(rng);
+    FType u1 = rng.template generate<FType>();
     while (u1 == 0) {
-      u1 = RandomReal<Rng, FType>::Generate(rng);
+      u1 = rng.template generate<FType>();
     }
-    const FType u2 = RandomReal<Rng, FType>::Generate(rng);
+    const FType u2 = rng.template generate<FType>();
     const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
     const FType v2 = two_pi * u2;
     *(offset + rng_id) = static_cast<DType>(CM::Fma(v1, CM::Cos(v2), mean));
@@ -248,11 +248,11 @@ __global__ void RandomGaussianKernel(
     *i = static_cast<DType>(CM::Fma(v1, CM::Sin(v2), mean));
   }
   if (2 * rng_id < size % (2 * n_rngs)) {
-    FType u1 = RandomReal<Rng, FType>::Generate(rng);
+    FType u1 = rng.template generate<FType>();
     while (u1 == 0) {
-      u1 = RandomReal<Rng, FType>::Generate(rng);
+      u1 = rng.template generate<FType>();
     }
-    const FType u2 = RandomReal<Rng, FType>::Generate(rng);
+    const FType u2 = rng.template generate<FType>();
     const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
     const FType v2 = two_pi * u2;
     DType* i = bound1 + 2 * rng_id;
@@ -437,7 +437,7 @@ struct UniformRealDistribution<gpu, Rng, DType> {
   MSHADOW_FORCE_INLINE __device__ result_type operator()(Rng& g) const {
     using CM = cuda::CuMath<FType>;
     return cuda::CastWithRounginDown<FType, DType>(
-      CM::FmaRD(FType(RandomReal<Rng, FType>::Generate(g)), w, a)
+      CM::FmaRD(g.template generate<FType>(), w, a)
     );
   }
 
@@ -470,11 +470,11 @@ struct GaussianDistribution<gpu, Rng, DType> {
     }
     using CM = cuda::CuMath<FType>;
     const FType two_pi = 6.283185307179586;
-    FType u1 = RandomReal<Rng, FType>::Generate(g);
+    FType u1 = g.template generate<FType>();
     while (u1 == 0) {
-      u1 = RandomReal<Rng, FType>::Generate(g);
+      u1 = g.template generate<FType>();
     }
-    const FType u2 = RandomReal<Rng, FType>::Generate(g);
+    const FType u2 = g.template generate<FType>();
     const FType v1 = stddev * CM::Sqrt(-FType(2) * CM::Log(u1));
     const FType v2 = two_pi * u2;
     spare = CM::Fma(v1, CM::Cos(v2), mean);

--- a/test/test_random.h
+++ b/test/test_random.h
@@ -1,0 +1,467 @@
+#pragma once
+
+#include <iostream>
+#include <limits>
+#include <type_traits>
+#include "mshadow/tensor.h"
+#include "assert.h"
+
+using namespace mshadow;
+using namespace std;
+
+using hf_t = mshadow::half::half_t;
+
+template<typename Device, int dim, typename DType, typename S>
+Tensor<Device, dim, DType> tensor(S shape, Stream<Device>* stream) {
+  Tensor<Device, dim, DType> ret(shape);
+  ret.set_stream(stream);
+  AllocSpace(&ret);
+  ret = 123;
+  return ret;
+}
+
+template<int dim, typename DType>
+Tensor<cpu, dim, DType> copyAndFree(Tensor<cpu, dim, DType>& t) {
+  return t;
+}
+
+template<typename DType>
+DType inc(DType f, unsigned n) {
+  for(unsigned i = 0; i < n; ++i) {
+    f = nextafter(f, std::numeric_limits<DType>::infinity());
+  }
+  return f;
+}
+
+#if MSHADOW_USE_CUDA
+template<int dim, typename DType>
+Tensor<cpu, dim, DType> copyAndFree(Tensor<gpu, dim, DType>& t) {
+  Tensor<cpu, dim, DType> ret(t.shape_);
+  AllocSpace(&ret);
+  Copy(ret, t, t.stream_);
+  FreeSpace(&t);
+  return ret;
+}
+#endif
+
+template<>
+hf_t inc<hf_t>(hf_t f, unsigned n) {
+  // Valid if the significand is close to 1
+  uint16_t ui = f.half_;
+  for(unsigned i = 0; i < n; ++i) {
+    ui = ((ui & 0x03ff) + 1) + (ui & 0xfc00);
+  }
+  return hf_t::Binary(ui);
+}
+
+template<typename T>
+MSHADOW_XINLINE const char* typenameString();
+
+template<>
+MSHADOW_XINLINE const char* typenameString<uint16_t>() {
+  return "uint16_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<int16_t>() {
+  return "int16_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<uint32_t>() {
+  return "uint32_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<int32_t>() {
+  return "int32_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<uint64_t>() {
+  return "uint64_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<int64_t>() {
+  return "int64_t";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<float>() {
+  return "float";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<double>() {
+  return "double";
+}
+
+template<>
+MSHADOW_XINLINE const char* typenameString<hf_t>() {
+  return "half_t";
+}
+
+template<typename Device, typename DType>
+bool CheckSeed(Stream<Device>* stream) {
+  cout << "Check Seed <" << typenameString<DType>() << ">" << endl;
+  {
+    // Generators initialized with the same seed should produce the same random number sequence
+    // The same default sequence id is used implicitly
+    auto ts0 = tensor<Device, 1, DType>(Shape1(10), stream);
+    auto ts1 = tensor<Device, 1, DType>(ts0.shape_, stream);
+    Random<Device, DType> rand0(0);
+    rand0.set_stream(stream);
+    rand0.SampleUniform(&ts0, DType(0), DType(10000));
+    Random<Device, DType> rand1(0);
+    rand1.set_stream(stream);
+    rand1.SampleUniform(&ts1, DType(0), DType(10000));
+    auto tr0 = copyAndFree(ts0);
+    auto tr1 = copyAndFree(ts1);
+    for (unsigned i = 0; i < tr0.size(0); ++i) {
+      assert(tr0[i] == tr1[i]);
+    }
+    FreeSpace(&tr0);
+    FreeSpace(&tr1);
+  }
+  {
+    // Generators initialized with different seeds should produce different random number sequences
+    // The same default sequence id is used implicitly
+    auto ts0 = tensor<Device, 1, DType>(Shape1(10), stream);
+    auto ts1 = tensor<Device, 1, DType>(ts0.shape_, stream);
+    Random<Device, DType> rand0(0);
+    rand0.set_stream(stream);
+    rand0.SampleUniform(&ts0, DType(0), DType(10000));
+    Random<Device, DType> rand1(1);
+    rand1.set_stream(stream);
+    rand1.SampleUniform(&ts1, DType(0), DType(10000));
+    auto tr0 = copyAndFree(ts0);
+    auto tr1 = copyAndFree(ts1);
+    for (unsigned i = 0; i < tr0.size(0); ++i) {
+      // Extremely low probability of the same numbers
+      assert(tr0[i] != tr1[i]);
+    }
+    FreeSpace(&tr0);
+    FreeSpace(&tr1);
+  }
+  {
+    // Check the effect of seeding after the initialization
+    auto ts0 = tensor<Device, 1, DType>(Shape1(10), stream);
+    auto ts1 = tensor<Device, 1, DType>(ts0.shape_, stream);
+    Random<Device, DType> rand0(0);
+    rand0.set_stream(stream);
+    rand0.SampleUniform(&ts0, DType(0), DType(10000));
+    Random<Device, DType> rand1(1);
+    rand1.set_stream(stream);
+    rand1.Seed(0);
+    rand1.SampleUniform(&ts1, DType(0), DType(10000));
+    auto tr0 = copyAndFree(ts0);
+    auto tr1 = copyAndFree(ts1);
+    for (unsigned i = 0; i < tr0.size(0); ++i) {
+      // Extremely low probability of the same numbers
+      assert(tr0[i] == tr1[i]);
+    }
+    FreeSpace(&tr0);
+    FreeSpace(&tr1);
+  }
+  return true;
+}
+
+template<typename Device, typename DType>
+bool CheckSequence(Stream<Device>* stream) {
+  cout << "Check Sequence <" << typenameString<DType>() << ">" << endl;
+  {
+    // Generators with different sequence id should generate different random numbers
+    auto ts0 = tensor<Device, 1, DType>(Shape1(10), stream);
+    auto ts1 = tensor<Device, 1, DType>(ts0.shape_, stream);
+    Random<Device, DType> rand0(0, 0);
+    rand0.set_stream(stream);
+    rand0.SampleUniform(&ts0, DType(0), DType(10000));
+    Random<Device, DType> rand1(0, 1);
+    rand0.set_stream(stream);
+    rand1.SampleUniform(&ts1, DType(0), DType(10000));
+    auto tr0 = copyAndFree(ts0);
+    auto tr1 = copyAndFree(ts1);
+    for (unsigned i = 0; i < tr0.size(0); ++i) {
+      assert(tr0[i] != tr1[i]);
+    }
+    FreeSpace(&tr0);
+    FreeSpace(&tr1);
+  }
+  {
+    // Effect of setting the sequence id after initialization
+    auto ts0 = tensor<Device, 1, DType>(Shape1(10), stream);
+    auto ts1 = tensor<Device, 1, DType>(ts0.shape_, stream);
+    Random<Device, DType> rand0(0, 0);
+    rand0.set_stream(stream);
+    rand0.SampleUniform(&ts0, DType(0), DType(10000));
+    Random<Device, DType> rand1(0, 1);
+    rand1.set_stream(stream);
+    rand1.Seed(0, 0);
+    rand1.SampleUniform(&ts1, DType(0), DType(10000));
+    auto tr0 = copyAndFree(ts0);
+    auto tr1 = copyAndFree(ts1);
+    for (unsigned i = 0; i < tr0.size(0); ++i) {
+      assert(tr0[i] == tr1[i]);
+    }
+    FreeSpace(&tr0);
+    FreeSpace(&tr1);
+  }
+  return true;
+}
+
+template<typename Device, typename DType>
+bool CheckGetRandInt(Stream<Device>* stream) {
+  cout << "Check GetRandInt <" << typenameString<DType>() << ">" << endl;
+  {
+    using uint_type = typename conditional<sizeof(DType) <= 4, uint32_t, uint64_t>::type;
+    auto ts = tensor<Device, 1, uint_type>(Shape1(10000), stream);
+    Random<Device, DType> rand(0);
+    rand.set_stream(stream);
+    rand.GetRandInt(ts);
+    auto tr = copyAndFree(ts);
+    const uint64_t max = numeric_limits<uint_type>::max();
+    for (unsigned i = 1; i < tr.size(0); ++i) {
+      assert(tr[i] <= max);
+      // Extremely low probability of the same integers in sequel
+      assert(tr[i] != tr[i - 1]);
+    }
+    FreeSpace(&tr);
+  }
+  {
+    // Tensor with any integer type should work
+    auto ts = tensor<Device, 1, int>(Shape1(10000), stream);
+    Random<Device, DType> rand(0);
+    rand.set_stream(stream);
+    rand.GetRandInt(ts);
+    auto tr = copyAndFree(ts);
+    for (unsigned i = 1; i < tr.size(0); ++i) {
+      // Extremely low probability of the same integers in sequel
+      assert(tr[i] != tr[i - 1]);
+    }
+    FreeSpace(&tr);
+  }
+  {
+    // Tensor with any integer type should work
+    auto ts = tensor<Device, 1, uint64_t>(Shape1(10000), stream);
+    Random<Device, DType> rand(0);
+    rand.set_stream(stream);
+    rand.GetRandInt(ts);
+    auto tr = copyAndFree(ts);
+    for (unsigned i = 1; i < tr.size(0); ++i) {
+      // Extremely low probability of same integers in sequel
+      assert(tr[i] != tr[i - 1]);
+    }
+    FreeSpace(&tr);
+  }
+  return true;
+}
+
+template<typename Device, typename DType>
+bool CheckSampleUniformInteger(Stream<Device>* stream) {
+  cout << "Check SampleUniformInteger <" << typenameString<DType>() << ">" << endl;
+  // Check the range and the first two moments of the generated random numbers.
+  {
+    for (DType lo = 0; lo < 10; ++lo) {
+      for (DType hi = lo; hi < lo + 10; ++hi) {
+        auto ts = tensor<Device, 2, DType>(Shape2(1000, 10000), stream);
+        Random<Device, DType> rand(9191);
+        rand.set_stream(stream);
+        rand.SampleUniform(&ts, lo, hi);
+        auto tr = copyAndFree(ts);
+        double x1 = 0;
+        double x2 = 0;
+        unsigned lower_bound_count = 0;
+        unsigned upper_bound_count = 0;
+        for (unsigned i = 0; i < tr.shape_[0]; ++i) {
+          for (unsigned j = 0; j < tr.shape_[1]; ++j) {
+            const DType x = tr[i][j];
+            assert(x != 1234); // Elements were initialized as 1234.
+            assert(lo <= x && x <= hi);
+            lower_bound_count += x == lo ? 1 : 0;
+            upper_bound_count += x == hi ? 1 : 0;
+            x1 += x;
+            x2 += x * x;
+          }
+        }
+        assert(lower_bound_count > 0);  // inclusive lower bound
+        assert(upper_bound_count > 0);  // inclusive upper bound
+        assert(abs(x1 / tr.shape_.Size() - (lo + hi) / 2.) < 0.1);
+        assert(abs(x2 / tr.shape_.Size() - (2 * (hi * hi + lo * lo + hi * lo) + hi - lo) / 6.) < 0.2);
+        FreeSpace(&tr);
+      }
+    }
+  }
+  // Runs only for signed type. Ignore the compiler warning.
+  if (is_signed<DType>::value) {
+    for (DType a = 1; a < 10; ++a) {
+      auto ts = tensor<Device, 2, DType>(Shape2(1000, 10000), stream);
+      Random<Device, DType> rand(9191);
+      rand.set_stream(stream);
+      rand.SampleUniform(&ts, DType(-a), a);
+      auto tr = copyAndFree(ts);
+      double x1 = 0;
+      double x2 = 0;
+      unsigned lower_bound_count = 0;
+      unsigned upper_bound_count = 0;
+      for (unsigned i = 0; i < tr.shape_[0]; ++i) {
+        for (unsigned j = 0; j < tr.shape_[1]; ++j) {
+          const DType x = tr[i][j];
+          assert(x != 1234); // Elements were initialized as 1234.
+          assert(-a <= x && x <= a);
+          lower_bound_count += x == -a ? 1 : 0;
+          upper_bound_count += x == a ? 1 : 0;
+          x1 += x;
+          x2 += x * x;
+        }
+      }
+      assert(lower_bound_count > 0); // Boundaries must be inclusive.
+      assert(upper_bound_count > 0); // Boundaries must be inclusive.
+      assert(abs(x1 / tr.shape_.Size() - 0) < 0.01);
+      assert(abs(x2 / tr.shape_.Size() - (1 + a) * a / 3.) < 0.1);
+      FreeSpace(&tr);
+    }
+  }
+  return true;
+}
+
+template<typename Device, typename DType>
+bool CheckSampleUniformReal(Stream<Device>* stream) {
+  cout << "Check SampleUniformReal <" << typenameString<DType>() << ">" << endl;
+  {
+    // Check the range and the first two moments of the generated random numbers.
+    auto ts = tensor<Device, 2, DType>(Shape2(10000, 10000), stream);
+    Random<Device, DType> rand(9191);
+    rand.set_stream(stream);
+    rand.SampleUniform(&ts, -5, 5);
+    auto tr = copyAndFree(ts);
+    double x1 = 0;
+    double x2 = 0;
+    for (unsigned i = 0; i < tr.shape_[0]; ++i) {
+      for (unsigned j = 0; j < tr.shape_[1]; ++j) {
+        const double x = tr[i][j];
+        assert(x != 1234); // Elements were initialized as 1234.
+        assert(-5 <= x && x < 5);
+        x1 += x;
+        x2 += x * x;
+      }
+    }
+    assert(abs(x1 / tr.shape_.Size() - 0) < 0.01);
+    assert(abs(x2 / tr.shape_.Size() - 100.0 / 12) < 1);
+    FreeSpace(&tr);
+  }
+  {
+    // The lower bound must be inclusive and the upper bound must be exclusive.
+    // We test only the exclusive upper bound.
+    // Testing inclusive lower bound is a nonsense.
+    for (unsigned i = 0; i < 10; ++i) {
+      for (unsigned j = 10; j < 20; ++j) {
+        auto ts = tensor<Device, 1, DType>(Shape1(10000000), stream);
+        Random<Device, DType> rand(9191);
+        rand.set_stream(stream);
+        const DType lo = inc(DType(1), i);
+        const DType hi = inc(lo, j);
+        rand.SampleUniform(&ts, lo, hi);
+        auto tr = copyAndFree(ts);
+        unsigned upper_bound_count = 0;
+        for (unsigned k = 0; k < tr.size(0); ++k) {
+          DType x = tr[k];
+          assert(lo <= x && x < hi);
+          upper_bound_count += x == hi ? 1 : 0;
+        }
+        assert(upper_bound_count == 0);
+      }
+    }
+  }
+  {
+    // Here the lower and upper bounds of the distribution are negative and close to 0.
+    for (unsigned i = 0; i < 10; ++i) {
+      for (unsigned j = 10; j < 20; ++j) {
+        auto ts = tensor<Device, 1, DType>(Shape1(10000000), stream);
+        Random<Device, DType> rand(9876);
+        rand.set_stream(stream);
+        const DType a = inc(DType(1), i);
+        const DType b = inc(a, j);
+        const DType lo = 1 - b;
+        const DType hi = 1 - a;
+        rand.SampleUniform(&ts, lo, hi);
+        auto tr = copyAndFree(ts);
+        unsigned upper_bound_count = 0;
+        for (unsigned k = 0; k < tr.size(0); ++k) {
+          DType x = tr[k];
+          assert(lo <= x && x < hi);
+          upper_bound_count += x == hi ? 1 : 0;
+        }
+        assert(upper_bound_count == 0);
+      }
+    }
+  }
+  return true;
+}
+
+template<typename Device, typename DType>
+bool CheckSampleGaussian(Stream<Device>* stream) {
+  cout << "Check SampleGaussian <" << typenameString<DType>() << ">" << endl;
+  {
+    // Check the first three moments of the generated random numbers.
+    for (DType m = 0; m < 1; m += 0.2) {
+      for (DType s = 1; s > 0; s -= 0.2) {
+        auto ts = tensor<Device, 2, DType>(Shape2(1000, 10000), stream);
+        Random<Device, DType> rand(0);
+        rand.set_stream(stream);
+        rand.SampleGaussian(&ts, m, s);
+        auto tr = copyAndFree(ts);
+        double x1 = 0;
+        double x2 = 0;
+        double x3 = 0;
+        double x4 = 0;
+        for (unsigned i = 0; i < tr.shape_[0]; ++i) {
+          for (unsigned j = 0; j < tr.shape_[1]; ++j) {
+            const double x = tr[i][j];
+            assert(x != 1234); // Elements were initialized as 1234.
+            x1 += x;
+            x2 += x * x;
+            x3 += x * x * x;
+            x4 += x * x * x * x;
+          }
+        }
+        assert(abs(x1 / tr.shape_.Size() - m) < 0.02);
+        assert(abs(x2 / tr.shape_.Size() - (m * m + s * s)) < 0.02);
+        assert(abs(x3 / tr.shape_.Size() - (m * m * m + 3 * m * s * s)) < 0.02);
+        FreeSpace(&tr);
+      }
+    }
+  }
+  {
+    // Test for an odd size tensor.
+    // The method to generate Gaussian random variables (Box-Muller or its variants)
+    // needs a separate test for odd size tensors and even size tensors.
+    for (DType m = 0; m < 1; m += 0.2) {
+      const DType s = 1;
+      auto ts = tensor<Device, 2, DType>(Shape2(999, 9999), stream);
+      Random<Device, DType> rand(0);
+      rand.set_stream(stream);
+      rand.SampleGaussian(&ts, m, s);
+      auto tr = copyAndFree(ts);
+      double x1 = 0;
+      double x2 = 0;
+      double x3 = 0;
+      double x4 = 0;
+      for (unsigned i = 0; i < tr.shape_[0]; ++i) {
+        for (unsigned j = 0; j < tr.shape_[1]; ++j) {
+          const double x = tr[i][j];
+          assert(x != 1234); // Elements were initialized as 1234.
+          x1 += x;
+          x2 += x * x;
+          x3 += x * x * x;
+          x4 += x * x * x * x;
+        }
+      }
+      assert(abs(x1 / tr.shape_.Size() - m) < 0.02);
+      assert(abs(x2 / tr.shape_.Size() - (m * m + s * s)) < 0.02);
+      assert(abs(x3 / tr.shape_.Size() - (m * m * m + 3 * m * s * s)) < 0.02);
+      FreeSpace(&tr);
+    }
+  }
+  return true;
+}

--- a/test/test_random_cpu.cc
+++ b/test/test_random_cpu.cc
@@ -1,0 +1,55 @@
+#include "test_random.h"
+
+int main() {
+  InitTensorEngine<cpu>();
+  Stream<cpu> *stream = NewStream<cpu>(false, false);
+
+  CheckSeed<cpu, int16_t>(stream);
+  CheckSeed<cpu, uint16_t>(stream);
+  CheckSeed<cpu, int32_t>(stream);
+  CheckSeed<cpu, uint32_t>(stream);
+  CheckSeed<cpu, int64_t>(stream);
+  CheckSeed<cpu, uint64_t>(stream);
+  CheckSeed<cpu, float>(stream);
+  CheckSeed<cpu, double>(stream);
+  CheckSeed<cpu, hf_t>(stream);
+
+  CheckSequence<cpu, int16_t>(stream);
+  CheckSequence<cpu, uint16_t>(stream);
+  CheckSequence<cpu, int32_t>(stream);
+  CheckSequence<cpu, uint32_t>(stream);
+  CheckSequence<cpu, int64_t>(stream);
+  CheckSequence<cpu, uint64_t>(stream);
+  CheckSequence<cpu, float>(stream);
+  CheckSequence<cpu, double>(stream);
+  CheckSequence<cpu, hf_t>(stream);
+
+  CheckGetRandInt<cpu, int16_t>(stream);
+  CheckGetRandInt<cpu, uint16_t>(stream);
+  CheckGetRandInt<cpu, int32_t>(stream);
+  CheckGetRandInt<cpu, uint32_t>(stream);
+  CheckGetRandInt<cpu, int64_t>(stream);
+  CheckGetRandInt<cpu, uint64_t>(stream);
+  CheckGetRandInt<cpu, float>(stream);
+  CheckGetRandInt<cpu, double>(stream);
+  CheckGetRandInt<cpu, hf_t>(stream);
+
+  CheckSampleUniformInteger<cpu, int16_t>(stream);
+  CheckSampleUniformInteger<cpu, uint16_t>(stream);
+  CheckSampleUniformInteger<cpu, int32_t>(stream);
+  CheckSampleUniformInteger<cpu, uint32_t>(stream);
+  CheckSampleUniformInteger<cpu, int64_t>(stream);
+  CheckSampleUniformInteger<cpu, uint64_t>(stream);
+
+  CheckSampleUniformReal<cpu, float>(stream);
+  CheckSampleUniformReal<cpu, double>(stream);
+  CheckSampleUniformReal<cpu, hf_t>(stream);
+
+  CheckSampleGaussian<cpu, float>(stream);
+  CheckSampleGaussian<cpu, double>(stream);
+  CheckSampleGaussian<cpu, hf_t>(stream);
+
+  DeleteStream(stream);
+  ShutdownTensorEngine<cpu>();
+  cout << "All checks passed" << endl;
+}

--- a/test/test_random_gpu.cu
+++ b/test/test_random_gpu.cu
@@ -1,0 +1,110 @@
+#include "test_random.h"
+
+template<typename Rng, typename DType>
+__global__ void CheckSampleUniformScalar(bool* check) {
+  printf("Check SampleUniformScalar <%s>\n", typenameString<DType>());
+  Rng rand;
+  mshadow::UniformRealDistribution<gpu, Rng, DType> dist;
+  const unsigned N = 1000000;
+  *check = true;
+  double x1 = 0;
+  double x2 = 0;
+  for (unsigned i = 0; i < N; ++i) {
+    double x = dist(rand);
+    x1 += x;
+    x2 += x * x;
+    *check = *check && (0 <= x && x < 1);
+  }
+  *check = *check && abs(x1 / N - 0.5) < 0.01 && abs(x2 / N - 1. / 3) < 0.01;
+}
+
+template<typename Rng, typename DType>
+__global__ void CheckSampleGaussianScalar(bool* check) {
+  printf("Check SampleGaussianScalar <%s>\n", typenameString<DType>());
+  Rng rand;
+  mshadow::GaussianDistribution<gpu, Rng, DType> dist;
+  const unsigned N = 1000000;
+  double x1 = 0;
+  double x2 = 0;
+  for (unsigned i = 0; i < N; ++i) {
+    double x = dist(rand);
+    x1 += x;
+    x2 += x * x;
+  }
+  *check = abs(x1 / N) < 0.01 && abs(x2 / N - 1) < 0.01;
+}
+
+template<typename DType>
+void CheckSampleScalar(Stream<gpu>* stream) {
+  cudaStream_t s = Stream<gpu>::GetStream(stream);
+  bool* check_dev;
+  cudaMalloc(&check_dev, sizeof(check_dev));
+  bool check = false;
+  using RandomBitGenerator = typename std::conditional<sizeof(DType) <= 4, PCGRandom32, PCGRandom64>::type;
+
+  CheckSampleUniformScalar<RandomBitGenerator, DType><<<1, 1, 0, s>>>(check_dev);
+  cudaMemcpy(&check, check_dev, sizeof(bool), cudaMemcpyDeviceToHost);
+  assert(check);
+
+  CheckSampleGaussianScalar<RandomBitGenerator, DType><<<1, 1, 0, s>>>(check_dev);
+  cudaMemcpy(&check, check_dev, sizeof(bool), cudaMemcpyDeviceToHost);
+  assert(check);
+}
+
+int main() {
+  InitTensorEngine<gpu>();
+  Stream<gpu> *stream = NewStream<gpu>(false, false);
+
+  CheckSeed<gpu, int16_t>(stream);
+  CheckSeed<gpu, uint16_t>(stream);
+  CheckSeed<gpu, int32_t>(stream);
+  CheckSeed<gpu, uint32_t>(stream);
+  CheckSeed<gpu, int64_t>(stream);
+  CheckSeed<gpu, uint64_t>(stream);
+  CheckSeed<gpu, float>(stream);
+  CheckSeed<gpu, double>(stream);
+  CheckSeed<gpu, hf_t>(stream);
+
+  CheckSequence<gpu, int16_t>(stream);
+  CheckSequence<gpu, uint16_t>(stream);
+  CheckSequence<gpu, int32_t>(stream);
+  CheckSequence<gpu, uint32_t>(stream);
+  CheckSequence<gpu, int64_t>(stream);
+  CheckSequence<gpu, uint64_t>(stream);
+  CheckSequence<gpu, float>(stream);
+  CheckSequence<gpu, double>(stream);
+  CheckSequence<gpu, hf_t>(stream);
+
+  CheckGetRandInt<gpu, int16_t>(stream);
+  CheckGetRandInt<gpu, uint16_t>(stream);
+  CheckGetRandInt<gpu, int32_t>(stream);
+  CheckGetRandInt<gpu, uint32_t>(stream);
+  CheckGetRandInt<gpu, int64_t>(stream);
+  CheckGetRandInt<gpu, uint64_t>(stream);
+  CheckGetRandInt<gpu, float>(stream);
+  CheckGetRandInt<gpu, double>(stream);
+  CheckGetRandInt<gpu, hf_t>(stream);
+
+  CheckSampleUniformInteger<gpu, int16_t>(stream);
+  CheckSampleUniformInteger<gpu, uint16_t>(stream);
+  CheckSampleUniformInteger<gpu, int32_t>(stream);
+  CheckSampleUniformInteger<gpu, uint32_t>(stream);
+  CheckSampleUniformInteger<gpu, int64_t>(stream);
+  CheckSampleUniformInteger<gpu, uint64_t>(stream);
+
+  CheckSampleUniformReal<gpu, float>(stream);
+  CheckSampleUniformReal<gpu, double>(stream);
+  CheckSampleUniformReal<gpu, hf_t>(stream);
+
+  CheckSampleGaussian<gpu, float>(stream);
+  CheckSampleGaussian<gpu, double>(stream);
+  CheckSampleGaussian<gpu, hf_t>(stream);
+
+  CheckSampleScalar<float>(stream);
+  CheckSampleScalar<double>(stream);
+  CheckSampleScalar<hf_t>(stream);
+
+  DeleteStream(stream);
+  ShutdownTensorEngine<gpu>();
+  cout << "All checks passed" << endl;
+}


### PR DESCRIPTION
### Overview

This PR proposes a new implementation of the random number generator in mshadow.

- Most importantly the new generator provides multiple _statistically independent_ streams of random numbers. For parallel computations with multiple random number generators, it is important to ensure the statistical independence between the generators. Bugs due to the hidden correlations are subtle and difficult to find out. Ensuring statistical independence of multiple random generator instances is the main motivation of this PR. MXNet uses multiple random generators but it guarantees only the independence of the generators on a single GPU device. There is no care on the independence of the generators in CPUs and multiple GPU devices. This PR would be used to remedy the situation.
- The new generator is faster and smaller.
- Address #213. The upper bound of the uniform distribution is exclusive.
- Address #306. `half_t` is already supported on CPU but the new generator also supports it on GPU.

### Implementation

New generators are based on the [PCG random generator](http://www.pcg-random.org/). PCG is statistically sound, fast, and small.  The mt19937 generator currently used on CPU is statistically less sound and does not provide an efficient way to implement multiple independent random sequences. This PR replaces `std::mt19937` with a C++11 style PCG generator. The inventor of the PCG provides a C++11 random engine implementation but the codebase is somewhat large in order to cover wide variations of the algorithm. So this PR has its own simple implementation tailored to the use in mshadow. The xorwow algorithm, currently used on GPU via curand host API, provides an efficient way to implement multiple independent random sequences, but the curand host API does not provide an interface to utilize the feature properly. Thus this PR replaces the curand host API with PCG generators parallely running on GPU.

### Performance

The performance gain depends on the probability distribution and the data type.

On CPU,
- The uniform distribution is 2.5x faster and the normal distribution is 1.5x faster for `float` and `double`.
- The uniform distribution is 3x faster and the normal distribution is 2x faster for `half_t`.

On GPU, the performance also depends on the number of parallel generators used. The number of generators used in curand host API is not known, but I guess it as 4096 from some observations with nvvp. If the number of generators is 4096 (the default),
- The uniform distributions in non-unit intervals and non-standard normal distributions are 2x~3x faster for both `float` and `double`.
- For `float`, the uniform distribution in the unit interval and the standard normal distribution are equivalent to the current ones.
- For `double`, the uniform distribution in the unit interval and the standard normal distribution are slower 1.5x. This is the only case that the new one is slower.
- Generation of `half_t` is 1.0x ~1.5x slower than `float` depending on the size of the tensor and the distribution.

### API change

- `mshadow::Random<cpu, Dtype>`'s constructor and `Seed` method get one additional integer argument to set the random number stream. A default value is provided. Two generators with the same seed but with different streams generate statistically independent random number sequences.
- `mshadow::Random<gpu, Dtype>`'s constructor and `Seed` method get two additional arguments. One is to set the random number stream and the other is to set the number of parallel generators to be used internally. A default value is provided for each.
- New classes `mshadow::PCGRandom32` and `mshadow::PCGRandom64`. They are C++11 random engines implementing PCG and can be used on both CPU and GPU.
- New classes `mshadow::UniformRealDistribution<Device, RandGenerator, DType>` and `mshadow::GaussianDistribution<Device, RandGenerator, DType>`. They correspond to `std::uniform_real_distribution` and `std::normal_distribution` but are more efficient if used with the provided PCG generators. They also work on both CPU and GPU.

### Compatibility

This PR does not break the API compatibility. It provides additional arguments with defaults for existing functions or introduces new ones. The behavior of the current API does not change except that it produces different random number sequences. I also checked that mxnet is compiled and passed the unit tests.
