### PR TITLE
Fix broken CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - wget
       - unzip
       - libblas-dev
+      - python3-pip
 
 before_install:
   - git clone https://github.com/dmlc/dmlc-core
@@ -23,7 +24,7 @@ before_install:
   - source ${TRAVIS}/travis_setup_env.sh
 
 install:
-  - pip install  --user  cpplint pylint
+  - pip3 install  --user  cpplint pylint
   
 script: scripts/travis_script.sh
 


### PR DESCRIPTION
The cpplint in CI is broken after https://github.com/dmlc/dmlc-core/pull/396. Now `dmlc-core/scripts/lint.py` runs in python3 and this breaks mshadow's CI. This PR attempts to fix the broken CI by catching up the change in dmlc-core.
