### PR TITLE
Improve batch gemm performance using MKL

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -166,6 +166,7 @@ extern "C" {
   #include <mkl_cblas.h>
   #include <mkl_vsl.h>
   #include <mkl_vsl_functions.h>
+  #include <mkl_version.h>
 #endif
 
 #if MSHADOW_USE_CUDA

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -300,13 +300,9 @@ struct BLASEngine<cpu, float> {
   std::vector<int> p_ldc(batch_count, ldc);
   std::vector<float> p_alpha(batch_count, alpha);
   std::vector<float> p_beta(batch_count, beta);
-
   std::vector<const float*> pp_A;
-  pp_A.reserve(batch_count);
   std::vector<const float*> pp_B;
-  pp_B.reserve(batch_count);
   std::vector<float*> pp_C;
-  pp_C.reserve(batch_count);
 
   CBLAS_TRANSPOSE cblas_a_trans = GetT(transa);
   CBLAS_TRANSPOSE cblas_b_trans = GetT(transb);
@@ -412,13 +408,9 @@ struct BLASEngine<cpu, double> {
   std::vector<int> p_ldc(batch_count, ldc);
   std::vector<double> p_alpha(batch_count, alpha);
   std::vector<double> p_beta(batch_count, beta);
-
   std::vector<const double*> pp_A;
-  pp_A.reserve(batch_count);
   std::vector<const double*> pp_B;
-  pp_B.reserve(batch_count);
   std::vector<double*> pp_C;
-  pp_C.reserve(batch_count);
 
   CBLAS_TRANSPOSE cblas_a_trans = GetT(transa);
   CBLAS_TRANSPOSE cblas_b_trans = GetT(transb);

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -7,6 +7,7 @@
 #ifndef MSHADOW_DOT_ENGINE_INL_H_
 #define MSHADOW_DOT_ENGINE_INL_H_
 
+#include <vector>
 #include "./base.h"
 #include "./extension/implicit_gemm.h"
 
@@ -315,18 +316,17 @@ struct BLASEngine<cpu, float> {
   auto k_n = k * n;
   auto m_n = m * n;
 
-  for(int i=0; i<batch_count; i++)
-  {
+  for (int i = 0; i < batch_count; i++) {
     pp_A.push_back(A + i * m_k);
     pp_B.push_back(B + i * k_n);
     pp_C.push_back(C + i * m_n);
   }
 
     cblas_sgemm_batch(CblasColMajor, p_transa.data(), p_transb.data(),
-		      p_m.data(), p_n.data(), p_k.data(),
-		      p_alpha.data(), pp_A.data(), p_lda.data(), pp_B.data(),
-		      p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
-		      1, p_group_sizeb.data());
+                      p_m.data(), p_n.data(), p_k.data(),
+                      p_alpha.data(), pp_A.data(), p_lda.data(), pp_B.data(),
+                      p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
+                      1, p_group_sizeb.data());
 #else
     for (int i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
@@ -423,18 +423,17 @@ struct BLASEngine<cpu, double> {
   auto k_n = k * n;
   auto m_n = m * n;
 
-  for(int i=0; i<batch_count; i++)
-  {
+  for (int i = 0; i < batch_count; i++) {
     pp_A.push_back(A + i * m_k);
     pp_B.push_back(B + i * k_n);
     pp_C.push_back(C + i * m_n);
   }
 
     cblas_dgemm_batch(CblasColMajor, p_transa.data(), p_transb.data(),
-		      p_m.data(), p_n.data(), p_k.data(),
-		      p_alpha.data(), pp_A.data(), p_lda.data(), pp_B.data(),
-		      p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
-		      1, p_group_sizeb.data());
+                      p_m.data(), p_n.data(), p_k.data(),
+                      p_alpha.data(), pp_A.data(), p_lda.data(), pp_B.data(),
+                      p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
+                      1, p_group_sizeb.data());
 #else
     for (int i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -292,7 +292,7 @@ struct BLASEngine<cpu, float> {
                                   const float *A, int lda, const float *B, int ldb,
                                   float beta, float *C, int ldc, int batch_count,
                                   float **workspace) {
-#if MSHADOW_USE_MKL
+#if (MSHADOW_USE_MKL && INTEL_MKL_VERSION >= 20160000)
   std::vector<int> p_m(batch_count, m);
   std::vector<int> p_n(batch_count, n);
   std::vector<int> p_k(batch_count, k);
@@ -399,7 +399,7 @@ struct BLASEngine<cpu, double> {
                                   const double *A, int lda, const double *B, int ldb,
                                   double beta, double *C, int ldc, int batch_count,
                                   double **workspace) {
-#if MSHADOW_USE_MKL
+#if (MSHADOW_USE_MKL && INTEL_MKL_VERSION >= 20160000)
   std::vector<int> p_m(batch_count, m);
   std::vector<int> p_n(batch_count, n);
   std::vector<int> p_k(batch_count, k);


### PR DESCRIPTION
This pr is to improve the performance of small size matrix batch gemm around 5-10x by using [MKL](https://software.intel.com/en-us/articles/introducing-batch-gemm-operations). This optimization will be useful for attention layer in [sockeye](https://github.com/awslabs/sockeye).

Performance comparison:

1000 loops

|  size                                 |    mshadow    |       MKL      |
|:---------------------------------:|:-------------:|:--------------:|
| [1120, 10, 256] * [1120, 256, 10] |  1.4739921093 | 0.180208921432 |
|  [1120, 40, 512] * [1120, 512, 1] | 3.45011711121 | 0.670109033585 |

@pengzhao-intel