### PR TITLE
Allow array size to be greater than 2^32

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -285,7 +285,7 @@ const unsigned kRandBufferSize = 1000000;
 /*! \brief pi  */
 const float kPi = 3.1415926f;
 /*! \brief type that will be used for index */
-typedef unsigned index_t;
+typedef size_t index_t;
 
 #ifdef _WIN32
   /*! \brief openmp index for windows */

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -116,7 +116,7 @@ class MSHADOW_ALIGNED(2) half_t {
   MSHADOW_XINLINE explicit half_t(const uint32_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const int64_t& value) { constructor(value); }
   // MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
-  // Replace constructor with uint64_t argument by the following two due to 
+  // Replace constructor with uint64_t argument by the following two due to
   // ambiguous casting from size_t
   MSHADOW_XINLINE explicit half_t(const unsigned long& value) { constructor(value); } /* NOLINT(*) */
   MSHADOW_XINLINE explicit half_t(const unsigned long long& value) { constructor(value); } /* NOLINT(*) */

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -115,11 +115,11 @@ class MSHADOW_ALIGNED(2) half_t {
   MSHADOW_XINLINE explicit half_t(const int32_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const uint32_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const int64_t& value) { constructor(value); }
-  //MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
-  //Replace constructor with uint64_t argument by the following two due to 
-  //ambiguous casting from size_t
-  MSHADOW_XINLINE explicit half_t(const unsigned long& value) { constructor(value); }
-  MSHADOW_XINLINE explicit half_t(const unsigned long long& value) { constructor(value); } 
+  // MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
+  // Replace constructor with uint64_t argument by the following two due to 
+  // ambiguous casting from size_t
+  MSHADOW_XINLINE explicit half_t(const unsigned long& value) { constructor(value); } /* NOLINT(*) */
+  MSHADOW_XINLINE explicit half_t(const unsigned long long& value) { constructor(value); } /* NOLINT(*) */
 
   MSHADOW_HALF_CONVERSIONOP(float)
 

--- a/mshadow/half.h
+++ b/mshadow/half.h
@@ -115,7 +115,11 @@ class MSHADOW_ALIGNED(2) half_t {
   MSHADOW_XINLINE explicit half_t(const int32_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const uint32_t& value) { constructor(value); }
   MSHADOW_XINLINE explicit half_t(const int64_t& value) { constructor(value); }
-  MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
+  //MSHADOW_XINLINE explicit half_t(const uint64_t& value) { constructor(value); }
+  //Replace constructor with uint64_t argument by the following two due to 
+  //ambiguous casting from size_t
+  MSHADOW_XINLINE explicit half_t(const unsigned long& value) { constructor(value); }
+  MSHADOW_XINLINE explicit half_t(const unsigned long long& value) { constructor(value); } 
 
   MSHADOW_HALF_CONVERSIONOP(float)
 


### PR DESCRIPTION
This change is needed to fix the [issue](https://github.com/apache/incubator-mxnet/issues/11495) that caused by converting an tensor of more than 2^32 elements to numpy.

