### PR TITLE
Upgrade pip before installing packages in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - wget
       - unzip
       - libblas-dev
+      - python3-pip
 
 before_install:
   - git clone https://github.com/dmlc/dmlc-core
@@ -23,7 +24,7 @@ before_install:
   - source ${TRAVIS}/travis_setup_env.sh
 
 install:
-  - pip install  --user  cpplint pylint
+  - pip3 install  --user  cpplint pylint
   
 script: scripts/travis_script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - source ${TRAVIS}/travis_setup_env.sh
 
 install:
+  - pip3 install --upgrade pip
   - pip3 install  --user  cpplint pylint
   
 script: scripts/travis_script.sh


### PR DESCRIPTION
Trying to resolve recent failures of CI. An example of the failure is https://travis-ci.org/dmlc/mshadow/jobs/405193399.