### PR TITLE
Add half_t support for batch_dot. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
   - source ${TRAVIS}/travis_setup_env.sh
 
 install:
+
+  - pip3 install --upgrade pip --user
   - pip3 install  --user  cpplint pylint
   
 script: scripts/travis_script.sh

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -531,11 +531,27 @@ struct BLASEngine<gpu, half::half_t> {
                                   const half::half_t *A, int lda, const half::half_t *B, int ldb,
                                   half::half_t beta, half::half_t *C, int ldc, int batch_count,
                                   half::half_t **workspace) {
+#if defined(__CUDACC__) && CUDA_VERSION >= 9000 && MSHADOW_CUDA_HALF
+    const __half* A_h = reinterpret_cast<const __half*>(A);
+    const __half* B_h = reinterpret_cast<const __half*>(B);
+    __half* alpha_h = reinterpret_cast<__half*>(&alpha);
+    __half* beta_h = reinterpret_cast<__half*>(&beta);
+    __half* C_h = reinterpret_cast<__half*>(C);
+
+    cublasStatus_t err = cublasHgemmStridedBatched(Stream<gpu>::GetBlasHandle(stream),
+      GetT(transa), GetT(transb), m, n, k, alpha_h,
+      A_h, lda, m * k,
+      B_h, ldb, k * n,
+      beta_h, C_h, ldc, m * n,
+      batch_count);
+    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Cublas: HgemmStridedBatched fail";
+#else
     for (int i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
            A + i * m * k, lda, B + i * k * n, ldb,
            beta, C + i * m * n, ldc);
     }
+#endif
   }
   inline static void gemv(Stream<gpu> *stream,
                           bool trans, int m, int n, half::half_t alpha,

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -531,7 +531,7 @@ struct BLASEngine<gpu, half::half_t> {
                                   const half::half_t *A, int lda, const half::half_t *B, int ldb,
                                   half::half_t beta, half::half_t *C, int ldc, int batch_count,
                                   half::half_t **workspace) {
-#if defined(__CUDACC__) && CUDA_VERSION >= 9000 && MSHADOW_CUDA_HALF
+#if defined(__CUDACC__) && CUDA_VERSION >= 9000
     const __half* A_h = reinterpret_cast<const __half*>(A);
     const __half* B_h = reinterpret_cast<const __half*>(B);
     __half* alpha_h = reinterpret_cast<__half*>(&alpha);

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -1,6 +1,6 @@
 # main script of travis
 if [ ${TASK} == "lint" ]; then
-    dmlc-core/scripts/lint.py mshadow all mshadow mshadow-ps || exit -1
+    python3 dmlc-core/scripts/lint.py mshadow all mshadow mshadow-ps || exit -1
 fi
 
 if [ ${TASK} == "doc" ]; then


### PR DESCRIPTION
https://github.com/apache/incubator-mxnet/issues/11796 
@DickJC123 @szhengac @szha 

crude benchmark
```
import mxnet as mx
a = mx.nd.ones((100,100,100), ctx=mx.gpu(), dtype='float16')
b = mx.nd.ones((100,100,100), ctx=mx.gpu(), dtype='float16')
for i in range(10):
    c = mx.nd.batch_dot(a,b)
mx.nd.waitall()
import time
begin = time.time()
for i in range(500):
    c = mx.nd.batch_dot(a,b)
mx.nd.waitall()
end = time.time()
print(end - begin)
```
Before:
`python tests.py`
0.9715321064

After:
`python tests.py`
0.0328528881073

Passed existing gpu batch_dot unit test in MXNet locally. 