### PR TITLE
Revert "Allow large array operation in MXNet (#348)"

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -285,7 +285,7 @@ const unsigned kRandBufferSize = 1000000;
 /*! \brief pi  */
 const float kPi = 3.1415926f;
 /*! \brief type that will be used for index */
-typedef int64_t index_t;
+typedef unsigned index_t;
 
 #ifdef _WIN32
   /*! \brief openmp index for windows */

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -123,8 +123,8 @@ struct Shape {
     return s;
   }
   /*! \return number of valid elements */
-  MSHADOW_XINLINE index_t Size(void) const {
-    index_t size = this->shape_[0];
+  MSHADOW_XINLINE size_t Size(void) const {
+    size_t size = this->shape_[0];
     #pragma unroll
     for (int i = 1; i < kDimension; ++i) {
       size *= this->shape_[i];
@@ -458,8 +458,8 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \tparam startdim the starting dimension
    */
   template<int startdim>
-  MSHADOW_XINLINE index_t MemSize(void) const {
-    index_t memsz = this->stride_;
+  MSHADOW_XINLINE size_t MemSize(void) const {
+    size_t memsz = this->stride_;
     #pragma unroll
     for (int i = startdim; i < kSubdim; ++i) {
       memsz *= this->shape_[i];
@@ -476,7 +476,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
   /*!
    * \return memory cost of the tensor, including the aligned x dimension
    */
-  MSHADOW_XINLINE index_t MSize(void) const {
+  MSHADOW_XINLINE size_t MSize(void) const {
     return this->MemSize<0>();
   }
   /*!
@@ -582,7 +582,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE bool CheckContiguous(void) const {
     return true;
   }
-  MSHADOW_XINLINE index_t MSize(void) const {
+  MSHADOW_XINLINE size_t MSize(void) const {
     return shape_[0];
   }
   MSHADOW_XINLINE index_t size(index_t i) const {


### PR DESCRIPTION
This reverts commit d68d3694fdfb44fdbb7c840c3591131ff2310a59.

This does not build as tvm nnvm::NodeEntry cannot accept input. tvm needs to be updated first.