### PR TITLE
Re-Revert PR #348 to support large tensor size in MXNet

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -23,7 +23,7 @@ the declaration in [mashadow/tensor.h](../mshadow/tensor.h)
 typedef unsigned index_t;
 template<int dimension>
 struct Shape {
-  index_t shape_[dimension];
+  size_t shape_[dimension];
 };
 template<typename Device, int dimension, typename DType = float>
 struct Tensor {
@@ -49,7 +49,7 @@ struct Shape<2> {
 struct Tensor<cpu, 2, float> {
   float *dptr_;
   Shape<2> shape_;
-  index_t stride_;
+  size_t stride_;
 };
 ```
 * ``` Tensor<cpu, 2>``` contains ```dptr_```, which points to the space that backs up the tensor.

--- a/guide/README.md
+++ b/guide/README.md
@@ -23,7 +23,7 @@ the declaration in [mashadow/tensor.h](../mshadow/tensor.h)
 typedef unsigned index_t;
 template<int dimension>
 struct Shape {
-  size_t shape_[dimension];
+  index_t shape_[dimension];
 };
 template<typename Device, int dimension, typename DType = float>
 struct Tensor {

--- a/guide/README.md
+++ b/guide/README.md
@@ -49,7 +49,7 @@ struct Shape<2> {
 struct Tensor<cpu, 2, float> {
   float *dptr_;
   Shape<2> shape_;
-  size_t stride_;
+  index_t stride_;
 };
 ```
 * ``` Tensor<cpu, 2>``` contains ```dptr_```, which points to the space that backs up the tensor.

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -285,7 +285,7 @@ const unsigned kRandBufferSize = 1000000;
 /*! \brief pi  */
 const float kPi = 3.1415926f;
 /*! \brief type that will be used for index */
-typedef unsigned index_t;
+typedef int64_t index_t;
 
 #ifdef _WIN32
   /*! \brief openmp index for windows */

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -206,7 +206,7 @@ MSHADOW_XINLINE Shape<2> Shape2(index_t s0, index_t s1) {
  * \param s2 size of dimension 2
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<3> Shape3(size_t s0, size_t s1, size_t s2) {
+MSHADOW_XINLINE Shape<3> Shape3(index_t s0, index_t s1, index_t s2) {
   Shape<3> s;
   s[0] = s0; s[1] = s1; s[2] = s2;
   return s;

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -420,7 +420,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \brief storing the stride information in x dimension
    *    this is used to deal with pitch allocation in gpu or sse(align x dimension to 64bit) for efficiency
    */
-  index_t stride_;
+  size_t stride_;
   /*!
    * \brief stream where the computation lies
    * stream is a device dependency concept where each computation
@@ -444,7 +444,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
   /*! \brief constructor from data pointer and shape  */
   MSHADOW_XINLINE Tensor(DType *dptr,
                          const Shape<dimension> &shape,
-                         index_t stride, Stream<Device> *stream)
+                         size_t stride, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(stride), stream_(stream) {}
   /*!
    * \brief set the stream to do computation of current tensor
@@ -552,7 +552,7 @@ struct Tensor<Device, 1, DType>:
  public:
   DType *dptr_;
   Shape<1> shape_;
-  index_t stride_;
+  size_t stride_;
   Stream<Device> *stream_;
   // constructor
   MSHADOW_XINLINE Tensor(void) : stream_(NULL) {}
@@ -563,7 +563,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE Tensor(DType *dptr, Shape<1> shape, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(shape[0]), stream_(stream) {}
   MSHADOW_XINLINE Tensor(DType *dptr, Shape<1> shape,
-                         index_t stride, Stream<Device> *stream)
+                         size_t stride, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(stride), stream_(stream) {}
   inline void set_stream(Stream<Device> *stream) {
     this->stream_ = stream;

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -54,7 +54,7 @@ struct Shape {
   /*! \brief dimension of current shape minus one */
   static const int kSubdim = dimension - 1;
   /*! \brief storing the dimension information */
-  index_t shape_[kDimension];
+  size_t shape_[kDimension];
   /*! \brief default constructor, do nothing */
   MSHADOW_XINLINE Shape(void) {}
   /*! \brief constuctor */
@@ -69,7 +69,7 @@ struct Shape {
    * \param idx dimension index
    * \return the corresponding dimension size
    */
-  MSHADOW_XINLINE index_t &operator[](index_t idx) {
+  MSHADOW_XINLINE size_t &operator[](index_t idx) {
     return shape_[idx];
   }
   /*!
@@ -77,7 +77,7 @@ struct Shape {
    * \param idx dimension index
    * \return the corresponding dimension size
    */
-  MSHADOW_XINLINE const index_t &operator[](index_t idx) const {
+  MSHADOW_XINLINE const size_t &operator[](index_t idx) const {
     return shape_[idx];
   }
   /*!
@@ -114,7 +114,7 @@ struct Shape {
   MSHADOW_XINLINE Shape<2> FlatTo2D(void) const {
     Shape<2> s;
     s.shape_[1] = this->shape_[kDimension - 1];
-    index_t ymax = 1;
+    size_t ymax = 1;
     #pragma unroll
     for (int i = 0; i < kDimension - 1; ++i) {
       ymax *= this->shape_[i];
@@ -136,8 +136,8 @@ struct Shape {
    * \param dimstart start dimension
    * \param dimend end dimension
    */
-  MSHADOW_XINLINE index_t ProdShape(int dimstart, int dimend) const {
-    index_t num = 1;
+  MSHADOW_XINLINE size_t ProdShape(int dimstart, int dimend) const {
+    size_t num = 1;
     #pragma unroll
     for (int i = dimstart; i < dimend; ++i) {
       num *= this->shape_[i];
@@ -185,7 +185,7 @@ v   * \return subshape
  * \param s0 size of dimension 0
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<1> Shape1(index_t s0) {
+MSHADOW_XINLINE Shape<1> Shape1(size_t s0) {
   Shape<1> s; s[0] = s0;
   return s;
 }
@@ -195,7 +195,7 @@ MSHADOW_XINLINE Shape<1> Shape1(index_t s0) {
  * \param s1 size of dimension 1
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<2> Shape2(index_t s0, index_t s1) {
+MSHADOW_XINLINE Shape<2> Shape2(size_t s0, size_t s1) {
   Shape<2> s; s[0] = s0; s[1] = s1;
   return s;
 }
@@ -206,7 +206,7 @@ MSHADOW_XINLINE Shape<2> Shape2(index_t s0, index_t s1) {
  * \param s2 size of dimension 2
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<3> Shape3(index_t s0, index_t s1, index_t s2) {
+MSHADOW_XINLINE Shape<3> Shape3(size_t s0, size_t s1, size_t s2) {
   Shape<3> s;
   s[0] = s0; s[1] = s1; s[2] = s2;
   return s;
@@ -219,8 +219,8 @@ MSHADOW_XINLINE Shape<3> Shape3(index_t s0, index_t s1, index_t s2) {
  * \param s3 size of dimension 3
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<4> Shape4(index_t s0, index_t s1,
-                                index_t s2, index_t s3) {
+MSHADOW_XINLINE Shape<4> Shape4(size_t s0, size_t s1,
+                                size_t s2, size_t s3) {
   Shape<4> s;
   s[0] = s0; s[1] = s1; s[2] = s2; s[3] = s3;
   return s;
@@ -234,8 +234,8 @@ MSHADOW_XINLINE Shape<4> Shape4(index_t s0, index_t s1,
 * \param s4 size of dimension 4
 * \return the shape construction
 */
-MSHADOW_XINLINE Shape<5> Shape5(index_t s0, index_t s1, index_t s2,
-                                index_t s3, index_t s4) {
+MSHADOW_XINLINE Shape<5> Shape5(size_t s0, size_t s1, size_t s2,
+                                size_t s3, size_t s4) {
   Shape<5> s;
   s[0] = s0; s[1] = s1; s[2] = s2; s[3] = s3; s[4] = s4;
   return s;
@@ -267,7 +267,7 @@ inline Shape<3> ConvertLayout(const Shape<3>& src, int src_layout, int dst_layou
     return dst;
   case kNWC:
     {
-      index_t tmp = dst[1];
+      size_t tmp = dst[1];
       dst[1] = dst[2];
       dst[2] = tmp;
     }
@@ -484,7 +484,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \param idx the dimension count from the highest dimensin
    * \return the size
    */
-  MSHADOW_XINLINE index_t size(index_t idx) const {
+  MSHADOW_XINLINE size_t size(index_t idx) const {
     return shape_[idx];
   }
   /*!
@@ -517,7 +517,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \return tensor after slice
    */
   MSHADOW_XINLINE Tensor<Device, dimension, DType>
-  Slice(index_t begin, index_t end) const {
+  Slice(size_t begin, size_t end) const {
     Shape<dimension> s = this->shape_;
     s[0] = end - begin;
     return Tensor<Device, dimension, DType>(dptr_ + this->MemSize<1>() * begin,
@@ -574,7 +574,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE Tensor<Device, 2, DType> FlatTo2D(void) const {
     return Tensor<Device, 2, DType>(dptr_, shape_.FlatTo2D(), stride_, stream_);
   }
-  MSHADOW_XINLINE Tensor<Device, 1, DType> Slice(index_t begin, index_t end) const {
+  MSHADOW_XINLINE Tensor<Device, 1, DType> Slice(size_t begin, size_t end) const {
     Shape<1> s;
     s[0] = end  - begin;
     return Tensor<Device, 1, DType>(dptr_ + begin, s, s[0], stream_);
@@ -585,7 +585,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE size_t MSize(void) const {
     return shape_[0];
   }
-  MSHADOW_XINLINE index_t size(index_t i) const {
+  MSHADOW_XINLINE size_t size(index_t i) const {
     return shape_[0];
   }
   MSHADOW_XINLINE DType &operator[](index_t idx) {

--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -54,7 +54,7 @@ struct Shape {
   /*! \brief dimension of current shape minus one */
   static const int kSubdim = dimension - 1;
   /*! \brief storing the dimension information */
-  size_t shape_[kDimension];
+  index_t shape_[kDimension];
   /*! \brief default constructor, do nothing */
   MSHADOW_XINLINE Shape(void) {}
   /*! \brief constuctor */
@@ -69,7 +69,7 @@ struct Shape {
    * \param idx dimension index
    * \return the corresponding dimension size
    */
-  MSHADOW_XINLINE size_t &operator[](index_t idx) {
+  MSHADOW_XINLINE index_t &operator[](index_t idx) {
     return shape_[idx];
   }
   /*!
@@ -77,7 +77,7 @@ struct Shape {
    * \param idx dimension index
    * \return the corresponding dimension size
    */
-  MSHADOW_XINLINE const size_t &operator[](index_t idx) const {
+  MSHADOW_XINLINE const index_t &operator[](index_t idx) const {
     return shape_[idx];
   }
   /*!
@@ -114,7 +114,7 @@ struct Shape {
   MSHADOW_XINLINE Shape<2> FlatTo2D(void) const {
     Shape<2> s;
     s.shape_[1] = this->shape_[kDimension - 1];
-    size_t ymax = 1;
+    index_t ymax = 1;
     #pragma unroll
     for (int i = 0; i < kDimension - 1; ++i) {
       ymax *= this->shape_[i];
@@ -123,8 +123,8 @@ struct Shape {
     return s;
   }
   /*! \return number of valid elements */
-  MSHADOW_XINLINE size_t Size(void) const {
-    size_t size = this->shape_[0];
+  MSHADOW_XINLINE index_t Size(void) const {
+    index_t size = this->shape_[0];
     #pragma unroll
     for (int i = 1; i < kDimension; ++i) {
       size *= this->shape_[i];
@@ -136,8 +136,8 @@ struct Shape {
    * \param dimstart start dimension
    * \param dimend end dimension
    */
-  MSHADOW_XINLINE size_t ProdShape(int dimstart, int dimend) const {
-    size_t num = 1;
+  MSHADOW_XINLINE index_t ProdShape(int dimstart, int dimend) const {
+    index_t num = 1;
     #pragma unroll
     for (int i = dimstart; i < dimend; ++i) {
       num *= this->shape_[i];
@@ -185,7 +185,7 @@ v   * \return subshape
  * \param s0 size of dimension 0
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<1> Shape1(size_t s0) {
+MSHADOW_XINLINE Shape<1> Shape1(index_t s0) {
   Shape<1> s; s[0] = s0;
   return s;
 }
@@ -195,7 +195,7 @@ MSHADOW_XINLINE Shape<1> Shape1(size_t s0) {
  * \param s1 size of dimension 1
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<2> Shape2(size_t s0, size_t s1) {
+MSHADOW_XINLINE Shape<2> Shape2(index_t s0, index_t s1) {
   Shape<2> s; s[0] = s0; s[1] = s1;
   return s;
 }
@@ -219,8 +219,8 @@ MSHADOW_XINLINE Shape<3> Shape3(size_t s0, size_t s1, size_t s2) {
  * \param s3 size of dimension 3
  * \return the shape construction
  */
-MSHADOW_XINLINE Shape<4> Shape4(size_t s0, size_t s1,
-                                size_t s2, size_t s3) {
+MSHADOW_XINLINE Shape<4> Shape4(index_t s0, index_t s1,
+                                index_t s2, index_t s3) {
   Shape<4> s;
   s[0] = s0; s[1] = s1; s[2] = s2; s[3] = s3;
   return s;
@@ -234,8 +234,8 @@ MSHADOW_XINLINE Shape<4> Shape4(size_t s0, size_t s1,
 * \param s4 size of dimension 4
 * \return the shape construction
 */
-MSHADOW_XINLINE Shape<5> Shape5(size_t s0, size_t s1, size_t s2,
-                                size_t s3, size_t s4) {
+MSHADOW_XINLINE Shape<5> Shape5(index_t s0, index_t s1, index_t s2,
+                                index_t s3, index_t s4) {
   Shape<5> s;
   s[0] = s0; s[1] = s1; s[2] = s2; s[3] = s3; s[4] = s4;
   return s;
@@ -267,7 +267,7 @@ inline Shape<3> ConvertLayout(const Shape<3>& src, int src_layout, int dst_layou
     return dst;
   case kNWC:
     {
-      size_t tmp = dst[1];
+      index_t tmp = dst[1];
       dst[1] = dst[2];
       dst[2] = tmp;
     }
@@ -420,7 +420,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \brief storing the stride information in x dimension
    *    this is used to deal with pitch allocation in gpu or sse(align x dimension to 64bit) for efficiency
    */
-  size_t stride_;
+  index_t stride_;
   /*!
    * \brief stream where the computation lies
    * stream is a device dependency concept where each computation
@@ -444,7 +444,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
   /*! \brief constructor from data pointer and shape  */
   MSHADOW_XINLINE Tensor(DType *dptr,
                          const Shape<dimension> &shape,
-                         size_t stride, Stream<Device> *stream)
+                         index_t stride, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(stride), stream_(stream) {}
   /*!
    * \brief set the stream to do computation of current tensor
@@ -458,8 +458,8 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \tparam startdim the starting dimension
    */
   template<int startdim>
-  MSHADOW_XINLINE size_t MemSize(void) const {
-    size_t memsz = this->stride_;
+  MSHADOW_XINLINE index_t MemSize(void) const {
+    index_t memsz = this->stride_;
     #pragma unroll
     for (int i = startdim; i < kSubdim; ++i) {
       memsz *= this->shape_[i];
@@ -476,7 +476,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
   /*!
    * \return memory cost of the tensor, including the aligned x dimension
    */
-  MSHADOW_XINLINE size_t MSize(void) const {
+  MSHADOW_XINLINE index_t MSize(void) const {
     return this->MemSize<0>();
   }
   /*!
@@ -484,7 +484,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \param idx the dimension count from the highest dimensin
    * \return the size
    */
-  MSHADOW_XINLINE size_t size(index_t idx) const {
+  MSHADOW_XINLINE index_t size(index_t idx) const {
     return shape_[idx];
   }
   /*!
@@ -517,7 +517,7 @@ struct Tensor: public TRValue<Tensor<Device, dimension, DType>,
    * \return tensor after slice
    */
   MSHADOW_XINLINE Tensor<Device, dimension, DType>
-  Slice(size_t begin, size_t end) const {
+  Slice(index_t begin, index_t end) const {
     Shape<dimension> s = this->shape_;
     s[0] = end - begin;
     return Tensor<Device, dimension, DType>(dptr_ + this->MemSize<1>() * begin,
@@ -552,7 +552,7 @@ struct Tensor<Device, 1, DType>:
  public:
   DType *dptr_;
   Shape<1> shape_;
-  size_t stride_;
+  index_t stride_;
   Stream<Device> *stream_;
   // constructor
   MSHADOW_XINLINE Tensor(void) : stream_(NULL) {}
@@ -563,7 +563,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE Tensor(DType *dptr, Shape<1> shape, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(shape[0]), stream_(stream) {}
   MSHADOW_XINLINE Tensor(DType *dptr, Shape<1> shape,
-                         size_t stride, Stream<Device> *stream)
+                         index_t stride, Stream<Device> *stream)
       : dptr_(dptr), shape_(shape), stride_(stride), stream_(stream) {}
   inline void set_stream(Stream<Device> *stream) {
     this->stream_ = stream;
@@ -574,7 +574,7 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE Tensor<Device, 2, DType> FlatTo2D(void) const {
     return Tensor<Device, 2, DType>(dptr_, shape_.FlatTo2D(), stride_, stream_);
   }
-  MSHADOW_XINLINE Tensor<Device, 1, DType> Slice(size_t begin, size_t end) const {
+  MSHADOW_XINLINE Tensor<Device, 1, DType> Slice(index_t begin, index_t end) const {
     Shape<1> s;
     s[0] = end  - begin;
     return Tensor<Device, 1, DType>(dptr_ + begin, s, s[0], stream_);
@@ -582,10 +582,10 @@ struct Tensor<Device, 1, DType>:
   MSHADOW_XINLINE bool CheckContiguous(void) const {
     return true;
   }
-  MSHADOW_XINLINE size_t MSize(void) const {
+  MSHADOW_XINLINE index_t MSize(void) const {
     return shape_[0];
   }
-  MSHADOW_XINLINE size_t size(index_t i) const {
+  MSHADOW_XINLINE index_t size(index_t i) const {
     return shape_[0];
   }
   MSHADOW_XINLINE DType &operator[](index_t idx) {


### PR DESCRIPTION
This PR is to patch a previous reverted PR #348 due to a build failure in MXNet.

This change is to fix the integer overflow issue in MXNet when a large tensor is created and converted to numpy. The related PR (https://github.com/apache/incubator-mxnet/pull/11742) in MXNet is pending this dependency to be merged.