### PR TITLE
Setting cuBLAS stream

### DIFF
--- a/mshadow/stream_gpu-inl.h
+++ b/mshadow/stream_gpu-inl.h
@@ -113,6 +113,8 @@ struct Stream<gpu> {
     cublasStatus_t err = cublasCreate(&blas_handle_);
     blas_handle_ownership_ = OwnHandle;
     CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Create cublas handle failed";
+    err = cublasSetStream(blas_handle_, stream_);
+    CHECK_EQ(err, CUBLAS_STATUS_SUCCESS) << "Setting cublas stream failed";
   }
 #if MSHADOW_USE_CUSOLVER == 1
   inline static cusolverDnHandle_t GetSolverHandle(Stream<gpu> *stream) {


### PR DESCRIPTION
This PR sets the cuBLAS stream, previously it used stream 0, causing synchronizations on the GPU side.