### PR TITLE
Return size_t from shape::size().

### DIFF
--- a/mshadow/tensor.h
+++ b/mshadow/tensor.h
@@ -123,7 +123,7 @@ struct Shape {
     return s;
   }
   /*! \return number of valid elements */
-  MSHADOW_XINLINE index_t Size(void) const {
+  MSHADOW_XINLINE size_t Size(void) const {
     index_t size = this->shape_[0];
     #pragma unroll
     for (int i = 1; i < kDimension; ++i) {


### PR DESCRIPTION
This issue blocks MXNet PR: https://github.com/apache/incubator-mxnet/pull/13697. https://github.com/apache/incubator-mxnet/pull/13729 is the corresponding fix for MXNet. After this fix, that PR can pass. Ref to https://github.com/apache/incubator-mxnet/pull/13755.