### PR TITLE
[WIP] Tensor shape overflow checking in Blas Engine

### DIFF
--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1104,7 +1104,9 @@ inline size_t mshadow_sizeof(int type) {
 
 
 /*!
- * \return true if multiplication won't overflow
+ * \param result the result of a * b is stored in result if the pointer is not nullptr
+ * \return true if multiplication of a and b won't overflow
+ * Uses division method
  */
 template<typename T>
 inline bool mult_not_overflow_binary(T a, T b, T *result = nullptr) {
@@ -1119,7 +1121,8 @@ inline bool mult_not_overflow_binary(T a, T b, T *result = nullptr) {
 }
 
 /*!
- * \return true if multiplication won't overflow
+ * Provide a list of operands to check if multiplying them will overflow
+ * \return true if multiplication won't overflow, false otherwise
  */
 template<typename T>
 inline bool mult_not_overflow(int count, ...) {
@@ -1135,13 +1138,22 @@ inline bool mult_not_overflow(int count, ...) {
   return true;
 }
 
+/*!
+ * @tparam From from type, wider than To
+ * @tparam To narrower type
+ * @param x argument
+ * @return true if the narrowing doesn't overflow, false otherwise
+ */
 template<typename From, typename To>
 inline bool narrow_not_overflow(From x) {
+  static_assert(sizeof(From) > sizeof(To), "valid only for narrowing conversions");
   if (static_cast<To>(x) >= static_cast<To>(std::numeric_limits<From>::min()) &&
     static_cast<To>(x) <= static_cast<To>(std::numeric_limits<From>::max()))
     return true;
   return false;
 }
+
+auto narrow_not_overflow_index_int = narrow_not_overflow<index_t, int>;
 
 }  // namespace mshadow
 #endif  // MSHADOW_BASE_H_

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1147,11 +1147,21 @@ inline bool mult_not_overflow(size_t count, ...) {
  */
 template<typename From, typename To>
 inline bool narrow_not_overflow(From x) {
-  static_assert(sizeof(From) > sizeof(To), "valid only for narrowing conversions");
-  if (static_cast<To>(x) >= static_cast<To>(std::numeric_limits<From>::min()) &&
-    static_cast<To>(x) <= static_cast<To>(std::numeric_limits<From>::max()))
-    return true;
-  return false;
+  using std::numeric_limits;
+  static_assert(numeric_limits<From>::is_integer, "only works for integers");
+  static_assert(numeric_limits<To>::is_integer, "only works for integers");
+  if (numeric_limits<To>::is_signed) {
+    if (static_cast<intmax_t>(x) < static_cast<intmax_t>(numeric_limits<To>::min()))
+      return false;
+    if (static_cast<intmax_t>(x) > static_cast<intmax_t>(numeric_limits<To>::max()))
+      return false;
+  } else {
+    if (x < 0)
+      return false;
+    if (x > static_cast<uintmax_t>(numeric_limits<To>::max()))
+      return false;
+  }
+  return true;
 }
 
 auto const narrow_not_overflow_index_int = narrow_not_overflow<index_t, int>;

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1158,7 +1158,7 @@ inline bool narrow_not_overflow(From x) {
   } else {
     if (x < 0)
       return false;
-    if (x > static_cast<uintmax_t>(numeric_limits<To>::max()))
+    if (static_cast<uintmax_t>(x) > static_cast<uintmax_t>(numeric_limits<To>::max()))
       return false;
   }
   return true;

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1102,5 +1102,17 @@ inline size_t mshadow_sizeof(int type) {
   return size;
 }
 
+template<typename T>
+inline bool mult_not_overflow(T a, T b, T *result = nullptr) {
+  static_assert(std::numeric_limits<T>::is_integer, "mult_not_overflow is only supported for integer types");
+  T res = {};
+  res = a * b;
+  if (a != 0 && (res / a) != b)
+    return false;
+  if (result)
+    *result = res;
+  return true;
+}
+
 }  // namespace mshadow
 #endif  // MSHADOW_BASE_H_

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1126,12 +1126,12 @@ inline bool mult_not_overflow_binary(T a, T b, T *result = nullptr) {
  * \return true if multiplication won't overflow, false otherwise
  */
 template<typename T>
-inline bool mult_not_overflow(int count, ...) {
+inline bool mult_not_overflow(size_t count, ...) {
   using namespace std;
   T accum = 1;
   va_list args;
   va_start(args, count);
-  for (int i=0; i < count; ++i) {
+  for (size_t i=0; i < count; ++i) {
     T x = va_arg(args, T);
     if(! mult_not_overflow_binary<T>(accum, x, &accum))
       return false;

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1102,8 +1102,12 @@ inline size_t mshadow_sizeof(int type) {
   return size;
 }
 
+
+/*!
+ * \return true if multiplication won't overflow
+ */
 template<typename T>
-inline bool mult_not_overflow(T a, T b, T *result = nullptr) {
+inline bool mult_not_overflow_binary(T a, T b, T *result = nullptr) {
   static_assert(std::numeric_limits<T>::is_integer, "mult_not_overflow is only supported for integer types");
   T res = {};
   res = a * b;
@@ -1112,6 +1116,31 @@ inline bool mult_not_overflow(T a, T b, T *result = nullptr) {
   if (result)
     *result = res;
   return true;
+}
+
+/*!
+ * \return true if multiplication won't overflow
+ */
+template<typename T>
+inline bool mult_not_overflow(int count, ...) {
+  using namespace std;
+  T accum = 1;
+  va_list args;
+  va_start(args, count);
+  for (int i=0; i < count; ++i) {
+    T x = va_arg(args, T);
+    if(! mult_not_overflow_binary<T>(accum, x, &accum))
+      return false;
+  }
+  return true;
+}
+
+template<typename From, typename To>
+inline bool narrow_not_overflow(From x) {
+  if (static_cast<To>(x) >= static_cast<To>(std::numeric_limits<From>::min()) &&
+    static_cast<To>(x) <= static_cast<To>(std::numeric_limits<From>::max()))
+    return true;
+  return false;
 }
 
 }  // namespace mshadow

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -1153,7 +1153,7 @@ inline bool narrow_not_overflow(From x) {
   return false;
 }
 
-auto narrow_not_overflow_index_int = narrow_not_overflow<index_t, int>;
+auto const narrow_not_overflow_index_int = narrow_not_overflow<index_t, int>;
 
 }  // namespace mshadow
 #endif  // MSHADOW_BASE_H_

--- a/mshadow/base.h
+++ b/mshadow/base.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <cstdarg>
 
 #ifdef _MSC_VER
 //! \cond Doxygen_Suppress

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -328,6 +328,10 @@ struct BLASEngine<cpu, float> {
                       p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
                       1, p_group_sizeb.data());
 #else
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(k));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(batch_count));
     CHECK(mult_not_overflow<int>(4, m, k, n, batch_count)) << "Tensor shapes arithmetic overflow int type";
     for (index_t i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
@@ -341,6 +345,11 @@ struct BLASEngine<cpu, float> {
                           float alpha, const float *A, index_t lda,
                           const float *X, index_t incX,
                           float beta, float *Y, index_t incY) {
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(lda));
+    CHECK(narrow_not_overflow_index_int(incX));
+    CHECK(narrow_not_overflow_index_int(incY));
     cblas_sgemv(CblasColMajor, GetT(trans), m, n, alpha,
                 A, lda, X, incX, beta, Y, incY);
   }
@@ -349,6 +358,14 @@ struct BLASEngine<cpu, float> {
                                   float alpha, const float *A, index_t lda,
                                   const float *X, index_t incX,
                                   float beta, float *Y, index_t incY, index_t batch_count) {
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(lda));
+    CHECK(narrow_not_overflow_index_int(incX));
+    CHECK(narrow_not_overflow_index_int(incY));
+    CHECK(narrow_not_overflow_index_int(batch_count));
+    CHECK(mult_not_overflow<int>(4, m, n, batch_count, incX)) << "Tensor shapes arithmetic overflow int type";
+    CHECK(mult_not_overflow<int>(4, m, n, batch_count, incY)) << "Tensor shapes arithmetic overflow int type";
     for (index_t i = 0; i < batch_count; ++i) {
       gemv(stream, trans, m, n, alpha, A + i * m * n, lda,
            X + i * (trans ? m : n) * incX, incX,
@@ -359,12 +376,25 @@ struct BLASEngine<cpu, float> {
                          index_t m, index_t n, float alpha,
                          const float *X, index_t incX,
                          const float *Y, index_t incY, float *A, index_t lda) {
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(lda));
+    CHECK(narrow_not_overflow_index_int(incX));
+    CHECK(narrow_not_overflow_index_int(incY));
     cblas_sger(CblasColMajor, m, n, alpha, X, incX, Y, incY, A, lda);
   }
   inline static void batched_ger(Stream<cpu> *stream,
                          index_t m, index_t n, float alpha,
                          const float *X, index_t incX,
                          const float *Y, index_t incY, float *A, index_t lda, index_t batch_count) {
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(lda));
+    CHECK(narrow_not_overflow_index_int(incX));
+    CHECK(narrow_not_overflow_index_int(incY));
+    CHECK(narrow_not_overflow_index_int(batch_count));
+    CHECK(mult_not_overflow<int>(4, m, batch_count, incX)) << "Tensor shapes arithmetic overflow int type";
+    CHECK(mult_not_overflow<int>(4, n, batch_count, incY)) << "Tensor shapes arithmetic overflow int type";
     for (index_t i = 0; i < batch_count; ++i) {
       ger(stream, m, n, alpha, X + i * m * incX, incX, Y + i * n * incY, incY,
           A + i * lda * n, lda);
@@ -504,6 +534,12 @@ struct BLASEngine<cpu, double> {
                          index_t m, index_t n, double alpha,
                          const double *X, index_t incX,
                          const double *Y, index_t incY, double *A, index_t lda, index_t batch_count) {
+    CHECK(narrow_not_overflow_index_int(m));
+    CHECK(narrow_not_overflow_index_int(n));
+    CHECK(narrow_not_overflow_index_int(lda));
+    CHECK(narrow_not_overflow_index_int(incX));
+    CHECK(narrow_not_overflow_index_int(incY));
+    CHECK(narrow_not_overflow_index_int(batch_count));
     CHECK(mult_not_overflow<int>(3, m, incX, batch_count)) << "Tensor shapes arithmetic overflow int type";
     CHECK(mult_not_overflow<int>(3, incY, n, batch_count)) << "Tensor shapes arithmetic overflow int type";
     CHECK(mult_not_overflow<int>(3, lda, n, batch_count)) << "Tensor shapes arithmetic overflow int type";

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -65,49 +65,49 @@ struct BLASEngine {
   }
   inline static void gemm(Stream<Device> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, DType alpha,
-                          const DType *A, int lda, const DType *B, int ldb,
-                          DType beta, DType *C, int ldc) {
+                          index_t m, index_t n, index_t k, DType alpha,
+                          const DType *A, index_t lda, const DType *B, index_t ldb,
+                          DType beta, DType *C, index_t ldc) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_gemm(Stream<Device> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, DType alpha,
-                                  const DType *A, int lda, const DType *B, int ldb,
-                                  DType beta, DType *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, DType alpha,
+                                  const DType *A, index_t lda, const DType *B, index_t ldb,
+                                  DType beta, DType *C, index_t ldc, index_t batch_count,
                                   DType **workspace) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void gemv(Stream<Device> *stream,
-                          bool trans, int m, int n,
-                          DType alpha, const DType *A, int lda,
-                          const DType *X, int incX,
-                          DType beta, DType *Y, int incY) {
+                          bool trans, index_t m, index_t n,
+                          DType alpha, const DType *A, index_t lda,
+                          const DType *X, index_t incX,
+                          DType beta, DType *Y, index_t incY) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_gemv(Stream<Device> *stream,
-                                  bool trans, int m, int n,
-                                  DType alpha, const DType *A, int lda,
-                                  const DType *X, int incX,
-                                  DType beta, DType *Y, int incY, int batch_count) {
+                                  bool trans, index_t m, index_t n,
+                                  DType alpha, const DType *A, index_t lda,
+                                  const DType *X, index_t incX,
+                                  DType beta, DType *Y, index_t incY, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<Device> *stream,
-                         int m, int n, DType alpha,
-                         const DType *X, int incX,
-                         const DType *Y, int incY, DType *A, int lda) {
+                         index_t m, index_t n, DType alpha,
+                         const DType *X, index_t incX,
+                         const DType *Y, index_t incY, DType *A, index_t lda) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_ger(Stream<Device> *stream,
-                         int m, int n, DType alpha,
-                         const DType *X, int incX,
-                         const DType *Y, int incY, DType *A, int lda, int batch_count) {
+                         index_t m, index_t n, DType alpha,
+                         const DType *X, index_t incX,
+                         const DType *Y, index_t incY, DType *A, index_t lda, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<Device> *stream,
-                         int n,
-                         const DType* X, int incX,
-                         const DType* Y, int incY,
+                         index_t n,
+                         const DType* X, index_t incX,
+                         const DType* Y, index_t incY,
                          DType* ret) {
     LOG(FATAL) << "Not implmented!";
   }
@@ -123,9 +123,9 @@ struct BLASEngine<cpu, float> {
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, float alpha,
-                          const float *A, int lda, const float *B, int ldb,
-                          float beta, float *C, int ldc) {
+                          index_t m, index_t n, index_t k, float alpha,
+                          const float *A, index_t lda, const float *B, index_t ldb,
+                          float beta, float *C, index_t ldc) {
     if (alpha == 1.0f && beta == 0.0f) {
       bool transpose_left = transb;
       bool transpose_right = transa;
@@ -147,46 +147,46 @@ struct BLASEngine<cpu, float> {
   }
   inline static void batched_gemm(Stream<cpu> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, float alpha,
-                                  const float *A, int lda, const float *B, int ldb,
-                                  float beta, float *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, float alpha,
+                                  const float *A, index_t lda, const float *B, index_t ldb,
+                                  float beta, float *C, index_t ldc, index_t batch_count,
                                   float **workspace) {
-    for (int i = 0; i < batch_count; ++i) {
+    for (index_t i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
            A + i * m * k, lda, B + i * k * n, ldb,
            beta, C + i * m * n, ldc);
     }
   }
   inline static void gemv(Stream<cpu> *stream,
-                          bool trans, int m, int n,
-                          float alpha, const float *A, int lda,
-                          const float *X, int incX,
-                          float beta, float *Y, int incY) {
+                          bool trans, index_t m, index_t n,
+                          float alpha, const float *A, index_t lda,
+                          const float *X, index_t incX,
+                          float beta, float *Y, index_t incY) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_gemv(Stream<cpu> *stream,
-                                  bool trans, int m, int n,
-                                  float alpha, const float *A, int lda,
-                                  const float *X, int incX,
-                                  float beta, float *Y, int incY, int batch_count) {
+                                  bool trans, index_t m, index_t n,
+                                  float alpha, const float *A, index_t lda,
+                                  const float *X, index_t incX,
+                                  float beta, float *Y, index_t incY, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
-                         int m, int n, float alpha,
-                         const float *X, int incX,
-                         const float *Y, int incY, float *A, int lda) {
+                         index_t m, index_t n, float alpha,
+                         const float *X, index_t incX,
+                         const float *Y, index_t incY, float *A, index_t lda) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_ger(Stream<cpu> *stream,
-                         int m, int n, float alpha,
-                         const float *X, int incX,
-                         const float *Y, int incY, float *A, int lda, int batch_count) {
+                         index_t m, index_t n, float alpha,
+                         const float *X, index_t incX,
+                         const float *Y, index_t incY, float *A, index_t lda, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
-                         int n,
-                         const float* X, int incX,
-                         const float* Y, int incY,
+                         index_t n,
+                         const float* X, index_t incX,
+                         const float* Y, index_t incY,
                          float* ret) {
     LOG(FATAL) << "Not implmented!";
   }
@@ -201,9 +201,9 @@ struct BLASEngine<cpu, double> {
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, double alpha,
-                          const double *A, int lda, const double *B, int ldb,
-                          double beta, double *C, int ldc) {
+                          index_t m, index_t n, index_t k, double alpha,
+                          const double *A, index_t lda, const double *B, index_t ldb,
+                          double beta, double *C, index_t ldc) {
     if (alpha == 1.0f && beta == 0.0f) {
       bool transpose_left = transb;
       bool transpose_right = transa;
@@ -225,46 +225,47 @@ struct BLASEngine<cpu, double> {
   }
   inline static void batched_gemm(Stream<cpu> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, double alpha,
-                                  const double *A, int lda, const double *B, int ldb,
-                                  double beta, double *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, double alpha,
+                                  const double *A, index_t lda, const double *B, index_t ldb,
+                                  double beta, double *C, index_t ldc, index_t batch_count,
                                   double **workspace) {
-    for (int i = 0; i < batch_count; ++i) {
+    CHECK(batch_count >= 0LL);
+    for (index_t i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
            A + i * m * k, lda, B + i * k * n, ldb,
            beta, C + i * m * n, ldc);
     }
   }
   inline static void gemv(Stream<cpu> *stream,
-                          bool trans, int m, int n,
-                          double alpha, const double *A, int lda,
-                          const double *X, int incX,
-                          double beta, double *Y, int incY) {
+                          bool trans, index_t m, index_t n,
+                          double alpha, const double *A, index_t lda,
+                          const double *X, index_t incX,
+                          double beta, double *Y, index_t incY) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_gemv(Stream<cpu> *stream,
-                                  bool trans, int m, int n,
-                                  double alpha, const double *A, int lda,
-                                  const double *X, int incX,
-                                  double beta, double *Y, int incY, int batch_count) {
+                                  bool trans, index_t m, index_t n,
+                                  double alpha, const double *A, index_t lda,
+                                  const double *X, index_t incX,
+                                  double beta, double *Y, index_t incY, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void ger(Stream<cpu> *stream,
-                         int m, int n, double alpha,
-                         const double *X, int incX,
-                         const double *Y, int incY, double *A, int lda) {
+                         index_t m, index_t n, double alpha,
+                         const double *X, index_t incX,
+                         const double *Y, index_t incY, double *A, index_t lda) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void batched_ger(Stream<cpu> *stream,
-                         int m, int n, double alpha,
-                         const double *X, int incX,
-                         const double *Y, int incY, double *A, int lda, int batch_count) {
+                         index_t m, index_t n, double alpha,
+                         const double *X, index_t incX,
+                         const double *Y, index_t incY, double *A, index_t lda, index_t batch_count) {
     LOG(FATAL) << "Not implmented!";
   }
   inline static void dot(Stream<cpu> *stream,
-                         int n,
-                         const double* X, int incX,
-                         const double* Y, int incY,
+                         index_t n,
+                         const double* X, index_t incX,
+                         const double* Y, index_t incY,
                          double* ret) {
     LOG(FATAL) << "Not implmented!";
   }
@@ -280,47 +281,54 @@ struct BLASEngine<cpu, float> {
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, float alpha,
-                          const float *A, int lda, const float *B, int ldb,
-                          float beta, float *C, int ldc) {
+                          index_t m, index_t n, index_t k, float alpha,
+                          const float *A, index_t lda, const float *B, index_t ldb,
+                          float beta, float *C, index_t ldc) {
     cblas_sgemm(CblasColMajor, GetT(transa), GetT(transb),
                 m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
   }
   inline static void batched_gemm(Stream<cpu> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, float alpha,
-                                  const float *A, int lda, const float *B, int ldb,
-                                  float beta, float *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, float alpha,
+                                  const float *A, index_t lda, const float *B, index_t ldb,
+                                  float beta, float *C, index_t ldc, index_t batch_count,
                                   float **workspace) {
 #if (MSHADOW_USE_MKL && INTEL_MKL_VERSION >= 20160000)
-  std::vector<int> p_m(batch_count, m);
-  std::vector<int> p_n(batch_count, n);
-  std::vector<int> p_k(batch_count, k);
-  std::vector<int> p_lda(batch_count, lda);
-  std::vector<int> p_ldb(batch_count, ldb);
-  std::vector<int> p_ldc(batch_count, ldc);
-  std::vector<float> p_alpha(batch_count, alpha);
-  std::vector<float> p_beta(batch_count, beta);
-  std::vector<const float*> pp_A;
-  std::vector<const float*> pp_B;
-  std::vector<float*> pp_C;
+    std::vector<int> p_m(batch_count, m);
+    std::vector<int> p_n(batch_count, n);
+    std::vector<int> p_k(batch_count, k);
+    std::vector<int> p_lda(batch_count, lda);
+    std::vector<int> p_ldb(batch_count, ldb);
+    std::vector<int> p_ldc(batch_count, ldc);
+    std::vector<float> p_alpha(batch_count, alpha);
+    std::vector<float> p_beta(batch_count, beta);
+    std::vector<const float*> pp_A;
+    std::vector<const float*> pp_B;
+    std::vector<float*> pp_C;
 
-  CBLAS_TRANSPOSE cblas_a_trans = GetT(transa);
-  CBLAS_TRANSPOSE cblas_b_trans = GetT(transb);
+    CBLAS_TRANSPOSE cblas_a_trans = GetT(transa);
+    CBLAS_TRANSPOSE cblas_b_trans = GetT(transb);
 
-  std::vector<int> p_group_sizeb(batch_count, batch_count);
-  std::vector<CBLAS_TRANSPOSE> p_transa(batch_count, cblas_a_trans);
-  std::vector<CBLAS_TRANSPOSE> p_transb(batch_count, cblas_b_trans);
+    std::vector<int> p_group_sizeb(batch_count, batch_count);
+    std::vector<CBLAS_TRANSPOSE> p_transa(batch_count, cblas_a_trans);
+    std::vector<CBLAS_TRANSPOSE> p_transb(batch_count, cblas_b_trans);
 
-  auto m_k = m * k;
-  auto k_n = k * n;
-  auto m_n = m * n;
 
-  for (int i = 0; i < batch_count; i++) {
-    pp_A.push_back(A + i * m_k);
-    pp_B.push_back(B + i * k_n);
-    pp_C.push_back(C + i * m_n);
-  }
+    int m_k = 0;
+    CHECK(mult_not_overflow(m,k, &m_k));
+    int k_n = 0;
+    CHECK(mult_not_overflow(k,n, &k_n));
+    int m_n = 0;
+    CHECK(mult_not_overflow(m,n, &m_n));
+
+    CHECK(mult_not_overflow(batch_count, m_k));
+    CHECK(mult_not_overflow(batch_count, k_n));
+    CHECK(mult_not_overflow(batch_count, m_n));
+    for (index_t i = 0; i < batch_count; ++i) {
+      pp_A.push_back(A + i * m_k);
+      pp_B.push_back(B + i * k_n);
+      pp_C.push_back(C + i * m_n);
+    }
 
     cblas_sgemm_batch(CblasColMajor, p_transa.data(), p_transb.data(),
                       p_m.data(), p_n.data(), p_k.data(),
@@ -328,7 +336,20 @@ struct BLASEngine<cpu, float> {
                       p_ldb.data(), p_beta.data(), pp_C.data(), p_ldc.data(),
                       1, p_group_sizeb.data());
 #else
-    for (int i = 0; i < batch_count; ++i) {
+    index_t m_k = 0;
+    CHECK(mult_not_overflow(m, k, &m_k));
+    index_t b_m_k = 0;
+    CHECK(mult_not_overflow(batch_count, m_k, &b_m_k));
+    index_t k_n = 0;
+    CHECK(mult_not_overflow(k, n, &k_n));
+    index_t b_k_n = 0;
+    CHECK(mult_not_overflow(batch_count, k_n, &b_k_n));
+    index_t m_n = 0;
+    CHECK(mult_not_overflow(m, n, &m_n));
+    index_t b_m_n = 0;
+    CHECK(mult_not_overflow(batch_count, m_n, &b_m_n));
+
+    for (index_t i = 0; i < batch_count; ++i) {
       gemm(stream, transa, transb, m, n, k, alpha,
            A + i * m * k, lda, B + i * k * n, ldb,
            beta, C + i * m * n, ldc);

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -8,7 +8,6 @@
 #define MSHADOW_DOT_ENGINE_INL_H_
 
 #include <vector>
-#include <cstdarg>
 #include "./base.h"
 #include "./extension/implicit_gemm.h"
 

--- a/mshadow/dot_engine-inl.h
+++ b/mshadow/dot_engine-inl.h
@@ -475,6 +475,9 @@ struct BLASEngine<cpu, double> {
     CHECK(mult_not_overflow<int>(3, m, k, batch_count)) << "Tensor shapes arithmetic overflow int type";
     CHECK(mult_not_overflow<int>(3, k, n, batch_count)) << "Tensor shapes arithmetic overflow int type";
     CHECK(mult_not_overflow<int>(3, m, n, batch_count)) << "Tensor shapes arithmetic overflow int type";
+    const int m_k = m * k;
+    const int k_n = k * n;
+    const int m_n = m * n;
     for (index_t i = 0; i < batch_count; i++) {
       pp_A.push_back(A + i * m_k);
       pp_B.push_back(B + i * k_n);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-mxnet/issues/14522

With this change, trying to multiply large matrices with BLAS Engine will cause the following exception in the python code instead of crashes inside blas.


```
Error in CustomOp.forward: Traceback (most recent call last):
  File "/Users/pllarroy/devel/mxnet/python/mxnet/operator.py", line 987, in forward_entry
    aux=tensors[4])
  File "repro.py", line 13, in forward
    c = mx.nd.batch_dot(a, b)
  File "<string>", line 59, in batch_dot
  File "/Users/pllarroy/devel/mxnet/python/mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "/Users/pllarroy/devel/mxnet/python/mxnet/base.py", line 252, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [15:47:54] /Users/pllarroy/devel/mxnet/include/mshadow/./dot_engine-inl.h:352: Check failed: mult_not_overflow<int>(batch_count, m_n, &b_m_n) Result Tensor shape (100x7000x6000) is too big, will overflow gemm signed 32 bit index

Stack trace returned 10 entries:
[bt] (0) 0   libmxnet.dylib                      0x0000000112bf1b7d dmlc::StackTrace() + 877
[bt] (1) 1   libmxnet.dylib                      0x0000000112bf16d5 dmlc::LogMessageFatal::~LogMessageFatal() + 53
[bt] (2) 2   libmxnet.dylib                      0x0000000112bcdf35 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (3) 3   libmxnet.dylib                      0x0000000114f2c91b mshadow::expr::BLASEngine<mshadow::cpu, float>::batched_gemm(mshadow::Stream<mshadow::cpu>*, bool, bool, long long, long long, long long, float, float const*, long long, float const*, long long, float, float*, long long, long long, float**) + 2139
[bt] (4) 4   libmxnet.dylib                      0x0000000114f21640 void mshadow::BatchGEMM<false, false, mshadow::cpu, float>(mshadow::Tensor<mshadow::cpu, 3, float>, mshadow::Tensor<mshadow::cpu, 3, float> const&, mshadow::Tensor<mshadow::cpu, 3, float> const&, float, float, mshadow::Tensor<mshadow::cpu, 1, float*>) + 4992
[bt] (5) 5   libmxnet.dylib                      0x0000000114eec939 void mxnet::op::BatchDotForward_<mshadow::cpu>(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&) + 3049
[bt] (6) 6   libmxnet.dylib                      0x0000000113100a55 void std::__1::__invoke_void_return_wrapper<void>::__call<void (*&)(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&), nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&>(void (*&&&)(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&), nnvm::NodeAttrs const&&&, mxnet::OpContext const&&&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&&&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&&&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&&&) + 277
[bt] (7) 7   libmxnet.dylib                      0x0000000113100869 std::__1::__function::__func<void (*)(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&), std::__1::allocator<void (*)(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&)>, void (nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&)>::operator()(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&) + 121
[bt] (8) 8   libmxnet.dylib                      0x0000000112ebf939 std::__1::function<void (nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&)>::operator()(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&) const + 217
[bt] (9) 9   libmxnet.dylib                      0x000000011306030f mxnet::imperative::PushFCompute(std::__1::function<void (nnvm::NodeAttrs const&, mxnet::OpContext const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, std::__1::vector<mxnet::TBlob, std::__1::allocator<mxnet::TBlob> > const&)> const&, nnvm::Op const*, nnvm::NodeAttrs const&, mxnet::Context const&, std::__1::vector<mxnet::engine::Var*, std::__1::allocator<mxnet::engine::Var*> > const&, std::__1::vector<mxnet::engine::Var*, std::__1::allocator<mxnet::engine::Var*> > const&, std::__1::vector<mxnet::Resource, std::__1::allocator<mxnet::Resource> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&)::'lambda'(mxnet::RunContext)::operator()(mxnet::RunContext) const + 2639
```